### PR TITLE
Fixing broken JDK 6 build

### DIFF
--- a/chef/core/src/main/java/org/jclouds/karaf/chef/core/ChefHelper.java
+++ b/chef/core/src/main/java/org/jclouds/karaf/chef/core/ChefHelper.java
@@ -340,7 +340,8 @@ public class ChefHelper {
         builder = builder.name(name).modules(ImmutableSet.<Module>of(new SLF4JLoggingModule()));
         builder = builder.name(name).credentials(clientName, clientCredential).overrides(chefConfig);
 
-        ChefContext context = builder.build();
+        // cast required for Java 6
+        ChefContext context = (ChefContext) builder.build();
         ChefService service = context.getChefService();
         return service;
     }


### PR DESCRIPTION
See https://github.com/jclouds/jclouds-karaf/pull/2, which was automatically closed because the branch was removed by a repo mirror operation.
