### PR TITLE
JCLOUDS-41: More fixes caused by a change in jclouds-chef

### DIFF
--- a/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefGroupBootStrap.java
+++ b/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefGroupBootStrap.java
@@ -23,6 +23,7 @@ import org.apache.felix.gogo.commands.Argument;
 import org.apache.felix.gogo.commands.Command;
 import org.apache.felix.gogo.commands.Option;
 import org.jclouds.chef.ChefService;
+import org.jclouds.chef.domain.BootstrapConfig;
 import org.jclouds.chef.util.RunListBuilder;
 import org.jclouds.scriptbuilder.domain.Statement;
 
@@ -61,7 +62,8 @@ public class ChefGroupBootStrap extends ChefRunscriptBase {
         ChefService chefService = getChefService();
         if (chefService != null) {
             List<String> runlist = new RunListBuilder().addRecipes(cookbook).build();
-            chefService.updateRunListForGroup(runlist, group);
+            BootstrapConfig bootstrapConfig = BootstrapConfig.builder().runList(runlist).build();
+            chefService.updateBootstrapConfigForGroup(group, bootstrapConfig);
             statement = chefService.createBootstrapScriptForGroup(group);
         }
         return statement;

--- a/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefNodeBootstrap.java
+++ b/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefNodeBootstrap.java
@@ -23,6 +23,7 @@ import org.apache.felix.gogo.commands.Argument;
 import org.apache.felix.gogo.commands.Command;
 import org.apache.felix.gogo.commands.Option;
 import org.jclouds.chef.ChefService;
+import org.jclouds.chef.domain.BootstrapConfig;
 import org.jclouds.chef.util.RunListBuilder;
 import org.jclouds.scriptbuilder.domain.Statement;
 
@@ -61,7 +62,8 @@ public class ChefNodeBootstrap extends ChefRunscriptBase {
         ChefService chefService = getChefService();
         if (chefService != null) {
             List<String> runlist = new RunListBuilder().addRecipes(cookbook).build();
-            chefService.updateRunListForGroup(runlist, "single");
+            BootstrapConfig bootstrapConfig = BootstrapConfig.builder().runList(runlist).build();
+            chefService.updateBootstrapConfigForGroup("single", bootstrapConfig);
             statement = chefService.createBootstrapScriptForGroup("single");
         }
         return statement;

--- a/chef/services/src/main/java/org/jclouds/karaf/chef/services/ChefRecipeProvider.java
+++ b/chef/services/src/main/java/org/jclouds/karaf/chef/services/ChefRecipeProvider.java
@@ -21,6 +21,7 @@ package org.jclouds.karaf.chef.services;
 
 import com.google.common.collect.Sets;
 import org.jclouds.chef.ChefService;
+import org.jclouds.chef.domain.BootstrapConfig;
 import org.jclouds.chef.domain.CookbookVersion;
 import org.jclouds.chef.util.RunListBuilder;
 import org.jclouds.karaf.recipe.RecipeProvider;
@@ -47,7 +48,8 @@ public class ChefRecipeProvider implements RecipeProvider {
     @Override
     public Statement createStatement(String recipe, String group) {
         List<String> runlist = new RunListBuilder().addRecipes(recipe).build();
-        chefService.updateRunListForGroup(runlist, group);
+        BootstrapConfig bootstrapConfig = BootstrapConfig.builder().runList(runlist).build();
+        chefService.updateBootstrapConfigForGroup(group, bootstrapConfig);
         return chefService.createBootstrapScriptForGroup(group);
     }
 


### PR DESCRIPTION
See https://git-wip-us.apache.org/repos/asf?p=incubator-jclouds-chef.git;a=commit;h=7f029db1c7b618494b47adb39d04aebebec726c3 and [JCLOUDS-3](https://issues.apache.org/jira/browse/JCLOUDS-3)

This PR addresses the regressions caused by the jclouds-chef change. https://github.com/jclouds/jclouds-karaf/pull/5 is also required for the build to (finally!) ata least compile again:
- JDK 6: https://jclouds.ci.cloudbees.com/view/integrations/job/jclouds-karaf-maybe-fixed/4/console (requires login)
- JDK 7: https://jclouds.ci.cloudbees.com/view/integrations/job/jclouds-karaf-maybe-fixed/2/console (requires login)

Note that the integration tests are all failing:

https://jclouds.ci.cloudbees.com/view/integrations/job/jclouds-karaf-maybe-fixed/2/testReport/

@iocanel: Any insights you can provide on that?
