### PR TITLE
JCLOUDS-41: Using builder.build(context) instead of an explicit cast

### DIFF
--- a/chef/core/src/main/java/org/jclouds/karaf/chef/core/ChefHelper.java
+++ b/chef/core/src/main/java/org/jclouds/karaf/chef/core/ChefHelper.java
@@ -340,8 +340,8 @@ public class ChefHelper {
         builder = builder.name(name).modules(ImmutableSet.<Module>of(new SLF4JLoggingModule()));
         builder = builder.name(name).credentials(clientName, clientCredential).overrides(chefConfig);
 
-        // cast required for Java 6
-        ChefContext context = (ChefContext) builder.build();
+        // builder.build() does not compile on JDK 6
+        ChefContext context = builder.build(ChefContext.class);
         ChefService service = context.getChefService();
         return service;
     }


### PR DESCRIPTION
Aligns the change made in [c94ed110a](https://git-wip-us.apache.org/repos/asf?p=incubator-jclouds-karaf.git;a=blobdiff;f=chef/core/src/main/java/org/jclouds/karaf/chef/core/ChefHelper.java;h=645050622b7987738213ffe84cc058ec6ba26d74;hp=637486ec1786c8f34399e4fbd20dd66fd6b3d958;hb=c94ed110a11cdb8ae737a900745cd995057b045d;hpb=68213a8db2cc5aa5a0d4ec41ea385b045b69d3b5) with the [code in 1.6.x](https://github.com/jclouds/jclouds-karaf/blob/1.6.x/chef/core/src/main/java/org/jclouds/karaf/chef/core/ChefHelper.java#L344)
