### PR TITLE
The blob read operation should print to STDOUT.

### DIFF
--- a/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobReadCommand.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobReadCommand.java
@@ -70,8 +70,8 @@ public class BlobReadCommand extends BlobStoreCommandWithOptions {
       InputSupplier<InputStream> supplier = getBlobInputStream(blobStore, containerName, blobName);
 
       if (display) {
-         CharStreams.copy(CharStreams.newReaderSupplier(supplier, Charsets.UTF_8), System.err);
-         System.err.flush();
+         CharStreams.copy(CharStreams.newReaderSupplier(supplier, Charsets.UTF_8), System.out);
+         System.out.flush();
       } else {
          File file = new File(fileName);
          if (!file.exists() && !file.createNewFile()) {


### PR DESCRIPTION
The Blob read operation accepts a --display option, which causes it
to print the contents of the blob. However, the contents are printed
to STDERR, as opposed to STDOUT.
