### PR TITLE
Add --signed-url option to blob read and write

### DIFF
--- a/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobReadCommand.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobReadCommand.java
@@ -52,11 +52,14 @@ public class BlobReadCommand extends BlobStoreCommandWithOptions {
    @Option(name = "-d", aliases = "--display", description = "Display the content to the console", required = false, multiValued = false)
    boolean display;
 
+   @Option(name = "-S", aliases = "--signed-request", description = "Use a signed request", required = false, multiValued = false)
+   boolean signedRequest;
+
    @Override
    protected Object doExecute() throws Exception {
       BlobStore blobStore = getBlobStore();
 
-      InputSupplier<InputStream> supplier = getBlobInputStream(blobStore, containerName, blobName);
+      InputSupplier<InputStream> supplier = getBlobInputStream(blobStore, containerName, blobName, signedRequest);
 
       if (display) {
          CharStreams.copy(CharStreams.newReaderSupplier(supplier, Charsets.UTF_8), System.out);

--- a/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobWriteCommand.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobWriteCommand.java
@@ -55,6 +55,9 @@ public class BlobWriteCommand extends BlobStoreCommandWithOptions {
    @Option(name = "-m", aliases = "--multipart-upload", description = "Use multi-part upload", required = false, multiValued = false)
    boolean multipartUpload;
 
+   @Option(name = "-S", aliases = "--signed-request", description = "Use a signed request", required = false, multiValued = false)
+   boolean signedRequest;
+
    @Override
    protected Object doExecute() throws Exception {
       BlobStore blobStore = getBlobStore();
@@ -78,7 +81,8 @@ public class BlobWriteCommand extends BlobStoreCommandWithOptions {
       }
 
       PutOptions options = multipartUpload ? new PutOptions().multipart(true) : PutOptions.NONE;
-      write(blobStore, containerName, blobName, builder.build(), options);
+
+      write(blobStore, containerName, blobName, builder.build(), options, signedRequest);
 
       cacheProvider.getProviderCacheForType("container").put(blobStore.getContext().unwrap().getId(), containerName);
       cacheProvider.getProviderCacheForType("blob").put(blobStore.getContext().unwrap().getId(), blobName);


### PR DESCRIPTION
This will allow future automation to script jclouds-cli and visualize
conformance of various optional features and semantic quirks.
