### PR TITLE
[JCLOUDS-189] Upgrade to Karaf 2.3.2. Explicitly specify jclouds feature...

### DIFF
--- a/cache/src/main/java/org/jclouds/karaf/cache/Activator.java
+++ b/cache/src/main/java/org/jclouds/karaf/cache/Activator.java
@@ -25,6 +25,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.util.tracker.ServiceTracker;
 
+import java.util.Hashtable;
 import java.util.Properties;
 
 public class Activator implements BundleActivator {
@@ -64,7 +65,7 @@ public class Activator implements BundleActivator {
     @Override
     public void start(BundleContext context) throws Exception {
         CacheProvider cacheProvider = new BasicCacheProvider();
-        cacheProviderRegistration = context.registerService(CacheProvider.class.getName(), cacheProvider, new Properties());
+        cacheProviderRegistration = context.registerService(CacheProvider.class.getName(), cacheProvider, new Hashtable<String, Object>());
 
         computeServiceTracker = CacheUtils.createServiceCacheTracker(context, ComputeService.class, computeCacheManager);
         computeCacheableTracker = CacheUtils.createCacheableTracker(context, "jclouds.computeservice",computeCacheManager);

--- a/chef/cache/src/main/java/org/jclouds/karaf/chef/cache/Activator.java
+++ b/chef/cache/src/main/java/org/jclouds/karaf/chef/cache/Activator.java
@@ -27,6 +27,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.util.tracker.ServiceTracker;
 
+import java.util.Hashtable;
 import java.util.Properties;
 
 public class Activator implements BundleActivator {
@@ -57,7 +58,7 @@ public class Activator implements BundleActivator {
     @Override
     public void start(BundleContext context) throws Exception {
         CacheProvider cacheProvider = new BasicCacheProvider();
-        cacheProviderRegistration = context.registerService(CacheProvider.class.getName(), cacheProvider, new Properties());
+        cacheProviderRegistration = context.registerService(CacheProvider.class.getName(), cacheProvider, new Hashtable<String, Object>());
 
 
         chefServiceTracker = CacheUtils.createServiceCacheTracker(context, ChefService.class, chefCacheManager);

--- a/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefServiceCreateCommand.java
+++ b/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefServiceCreateCommand.java
@@ -29,10 +29,7 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 
-import java.util.Dictionary;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 @Command(scope = "chef", name = "service-create", description = "Creates a chef service")
 public class ChefServiceCreateCommand extends ChefCommandWithOptions {
@@ -126,9 +123,9 @@ public class ChefServiceCreateCommand extends ChefCommandWithOptions {
                     Configuration configuration = findOrCreateFactoryConfiguration(configurationAdmin, "org.jclouds.chef", name, api);
                     if (configuration != null) {
                         @SuppressWarnings("unchecked")
-                        Dictionary<Object, Object> dictionary = configuration.getProperties();
+                        Dictionary<String, Object> dictionary = configuration.getProperties();
                         if (dictionary == null) {
-                            dictionary = new Properties();
+                            dictionary = new Hashtable<String, Object>();
                         }
 
                         String apiValue = ChefHelper.getChefApi(api);

--- a/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobStoreServiceCreateCommand.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobStoreServiceCreateCommand.java
@@ -29,10 +29,7 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 
-import java.util.Dictionary;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 @Command(scope = "jclouds", name = "blobstore-service-create", description = "Creates a BlobStore service.", detailedDescription = "classpath:blobstore-service-create.txt")
 public class BlobStoreServiceCreateCommand extends BlobStoreCommandWithOptions {
@@ -141,9 +138,9 @@ public class BlobStoreServiceCreateCommand extends BlobStoreCommandWithOptions {
                         "org.jclouds.blobstore", id, provider, api);
                if (configuration != null) {
                   @SuppressWarnings("unchecked")
-                  Dictionary<Object, Object> dictionary = configuration.getProperties();
+                  Dictionary<String, Object> dictionary = configuration.getProperties();
                   if (dictionary == null) {
-                     dictionary = new Properties();
+                     dictionary = new Hashtable<String, Object>();
                   }
 
                   String providerValue = EnvHelper.getBlobStoreProvider(provider);

--- a/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeServiceCreateCommand.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeServiceCreateCommand.java
@@ -17,10 +17,7 @@
 
 package org.jclouds.karaf.commands.compute;
 
-import java.util.Dictionary;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 import org.apache.felix.gogo.commands.Command;
 import org.apache.felix.gogo.commands.Option;
@@ -140,9 +137,9 @@ public class ComputeServiceCreateCommand extends ComputeCommandWithOptions {
                Configuration configuration = findOrCreateFactoryConfiguration(configurationAdmin, "org.jclouds.compute", name, provider, api);
                if (configuration != null) {
                   @SuppressWarnings("unchecked")
-                  Dictionary<Object, Object> dictionary = configuration.getProperties();
+                  Dictionary<String, Object> dictionary = configuration.getProperties();
                   if (dictionary == null) {
-                     dictionary = new Properties();
+                     dictionary = new Hashtable<String, Object>();
                   }
 
                   String providerValue = EnvHelper.getComputeProvider(provider);

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -104,6 +104,61 @@ limitations under the License.
               <descriptors>
                 <descriptor>file:${basedir}/target/feature.xml</descriptor>
               </descriptors>
+              <features>
+                <feature>jclouds</feature>
+                <feature>jclouds-blobstore</feature>
+                <feature>jclouds-compute</feature>
+                <feature>jclouds-management</feature>
+                <feature>jclouds-api-filesystem</feature>
+                <feature>jclouds-api-elasticstack</feature>
+                <feature>jclouds-api-vcloud</feature>
+                <feature>jclouds-api-byon</feature>
+                <feature>jclouds-api-swift</feature>
+                <feature>jclouds-api-openstack-nova</feature>
+                <feature>jclouds-api-openstack-keystone</feature>
+                <feature>jclouds-api-openstack-cinder</feature>
+                <feature>jclouds-aws-cloudwatch</feature>
+                <feature>jclouds-aws-ec2</feature>
+                <feature>jclouds-aws-route53</feature>
+                <feature>jclouds-aws-s3</feature>
+                <feature>jclouds-aws-sqs</feature>
+                <feature>jclouds-aws-sts</feature>
+                <feature>jclouds-azureblob</feature>
+                <feature>jclouds-bluelock-vcloud-zone01</feature>
+                <feature>jclouds-cloudfiles-uk</feature>
+                <feature>jclouds-cloudfiles-us</feature>
+                <feature>jclouds-dynect</feature>
+                <feature>jclouds-rackspace-cloudloadbalancers-us</feature>
+                <feature>jclouds-rackspace-cloudloadbalancers-uk</feature>
+                <feature>jclouds-cloudonestorage</feature>
+                <feature>jclouds-cloudserver-uk</feature>
+                <feature>jclouds-cloudserver-us</feature>
+                <feature>jclouds-rackspace-cloudservers-us</feature>
+                <feature>jclouds-rackspace-cloudservers-uk</feature>
+                <feature>jclouds-rackspace-clouddns-us</feature>
+                <feature>jclouds-rackspace-clouddns-uk</feature>
+                <feature>jclouds-rackspace-cloudblockstorage-us</feature>
+                <feature>jclouds-rackspace-cloudblockstorage-uk</feature>
+                <feature>jclouds-cloudsigma-zrh</feature>
+                <feature>jclouds-cloudsigma-lvs</feature>
+                <feature>jclouds-elastichosts-lon-b</feature>
+                <feature>jclouds-elastichosts-lon-p</feature>
+                <feature>jclouds-elastichosts-sat-p</feature>
+                <feature>jclouds-elastichosts-lax-p</feature>
+                <feature>jclouds-elastichosts-tor-p</feature>
+                <feature>jclouds-gogrid</feature>
+                <feature>jclouds-go2cloud-jhb1</feature>
+                <feature>jclouds-greenhousedata-element-vcloud</feature>
+                <feature>jclouds-glesys</feature>
+                <feature>jclouds-hpcloud-objectstorage</feature>
+                <feature>jclouds-hpcloud-compute</feature>
+                <feature>jclouds-ninefold-storage</feature>
+                <feature>jclouds-ninefold-compute</feature>
+                <feature>jclouds-openhosting-east1</feature>
+                <feature>jclouds-serverlove-z1-man</feature>
+                <feature>jclouds-skalicloud-sdg-my</feature>
+                <feature>jclouds-softlayer</feature>
+              </features>
               <repository>target/features-repo</repository>
             </configuration>
           </execution>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -108,10 +108,15 @@ limitations under the License.
 
 
     <dependency>
-      <groupId>org.openengsb.labs.paxexam.karaf</groupId>
-      <artifactId>paxexam-karaf-container</artifactId>
-      <scope>test</scope>
+      <groupId>org.apache.karaf.tooling.exam</groupId>
+      <artifactId>org.apache.karaf.tooling.exam.options</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.karaf.tooling.exam</groupId>
+      <artifactId>org.apache.karaf.tooling.exam.container</artifactId>
+    </dependency>
+
 
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
@@ -170,6 +175,8 @@ limitations under the License.
             <exclude>**/special/*Test.*</exclude>
           </excludes>
           <systemPropertyVariables>
+            <!-- Private Maven Repo -->
+            <maven.repo.local>${maven.repo.local}</maven.repo.local>
             <!-- EC2 Live Variables -->
             <jclouds.aws.identity>${jclouds.aws.identity}</jclouds.aws.identity>
             <jclouds.aws.credential>${jclouds.aws.credential}</jclouds.aws.credential>

--- a/itests/src/test/java/org/jclouds/karaf/itests/AwsFeaturesInstallationTest.java
+++ b/itests/src/test/java/org/jclouds/karaf/itests/AwsFeaturesInstallationTest.java
@@ -50,7 +50,6 @@ public class AwsFeaturesInstallationTest extends JcloudsFeaturesTestSupport {
         installAndCheckFeature("jclouds-aws-sqs");
     }
 
-    @Ignore
     @Test
     public void testAwsStsFeature() throws Exception {
         installAndCheckFeature("jclouds-aws-sts");

--- a/itests/src/test/java/org/jclouds/karaf/itests/JcloudsFeaturesTestSupport.java
+++ b/itests/src/test/java/org/jclouds/karaf/itests/JcloudsFeaturesTestSupport.java
@@ -18,11 +18,11 @@
 package org.jclouds.karaf.itests;
 
 import static junit.framework.Assert.assertTrue;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.logLevel;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.logLevel;
 
 import org.apache.karaf.features.FeaturesService;
-import org.openengsb.labs.paxexam.karaf.options.LogLevelOption;
+import org.apache.karaf.tooling.exam.options.LogLevelOption;
 import org.ops4j.pax.exam.MavenUtils;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.Configuration;

--- a/itests/src/test/java/org/jclouds/karaf/itests/JcloudsKarafTestSupport.java
+++ b/itests/src/test/java/org/jclouds/karaf/itests/JcloudsKarafTestSupport.java
@@ -17,8 +17,8 @@
 
 package org.jclouds.karaf.itests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.editConfigurationFileExtend;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.karafDistributionConfiguration;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.editConfigurationFileExtend;
 import static org.ops4j.pax.exam.CoreOptions.maven;
 
 import java.io.ByteArrayOutputStream;
@@ -39,6 +39,7 @@ import org.ops4j.pax.exam.MavenUtils;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.ProbeBuilder;
+import org.ops4j.pax.exam.options.DefaultCompositeOption;
 import org.ops4j.pax.exam.options.MavenArtifactProvisionOption;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -48,6 +49,8 @@ import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.util.tracker.ServiceTracker;
+
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.editConfigurationFileExtend;
 
 public class JcloudsKarafTestSupport {
 
@@ -86,9 +89,16 @@ public class JcloudsKarafTestSupport {
      * @return
      */
     protected Option jcloudsDistributionConfiguration() {
-        return karafDistributionConfiguration().frameworkUrl(
-                maven().groupId(KARAF_GROUP_ID).artifactId(KARAF_ARTIFACT_ID).versionAsInProject().type("tar.gz"))
-                .karafVersion(getKarafVersion()).name("Apache Karaf Distro").unpackDirectory(new File("target/paxexam/unpack/"));
+        return new DefaultCompositeOption(karafDistributionConfiguration()
+                .frameworkUrl(maven()
+                        .groupId(KARAF_GROUP_ID)
+                        .artifactId(KARAF_ARTIFACT_ID)
+                        .versionAsInProject().type("tar.gz"))
+                .karafVersion(getKarafVersion()).name("Apache Karaf Distro")
+                .unpackDirectory(new File("target/paxexam/unpack/")),
+                //We use this option to allow the container to use artifacts found in a private repo.
+                editConfigurationFileExtend("etc/org.ops4j.pax.url.mvn.cfg", "org.ops4j.pax.url.mvn.repositories",", file:${maven.local.repo}@id=mavenlocalrepo@snapshots")
+        );
     }
 
     /**

--- a/itests/src/test/java/org/jclouds/karaf/itests/MiscFeaturesInstallationTest.java
+++ b/itests/src/test/java/org/jclouds/karaf/itests/MiscFeaturesInstallationTest.java
@@ -19,7 +19,6 @@ package org.jclouds.karaf.itests;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;

--- a/itests/src/test/java/org/jclouds/karaf/itests/live/AwsEc2LiveTest.java
+++ b/itests/src/test/java/org/jclouds/karaf/itests/live/AwsEc2LiveTest.java
@@ -18,8 +18,8 @@
 package org.jclouds.karaf.itests.live;
 
 import static org.junit.Assert.assertTrue;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.logLevel;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.logLevel;
 import static org.ops4j.pax.exam.CoreOptions.scanFeatures;
 
 import org.jclouds.compute.ComputeService;
@@ -27,7 +27,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openengsb.labs.paxexam.karaf.options.LogLevelOption;
+import org.apache.karaf.tooling.exam.options.LogLevelOption;
 import org.ops4j.pax.exam.MavenUtils;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.Configuration;

--- a/itests/src/test/java/org/jclouds/karaf/itests/live/AwsS3LiveTest.java
+++ b/itests/src/test/java/org/jclouds/karaf/itests/live/AwsS3LiveTest.java
@@ -19,8 +19,8 @@ package org.jclouds.karaf.itests.live;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.logLevel;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.logLevel;
 import static org.ops4j.pax.exam.CoreOptions.scanFeatures;
 
 import java.io.File;
@@ -38,7 +38,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openengsb.labs.paxexam.karaf.options.LogLevelOption;
+import org.apache.karaf.tooling.exam.options.LogLevelOption;
 import org.ops4j.pax.exam.MavenUtils;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.Configuration;

--- a/itests/src/test/java/org/jclouds/karaf/itests/live/CloudFilesUsLiveTest.java
+++ b/itests/src/test/java/org/jclouds/karaf/itests/live/CloudFilesUsLiveTest.java
@@ -19,8 +19,8 @@ package org.jclouds.karaf.itests.live;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.logLevel;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.logLevel;
 import static org.ops4j.pax.exam.CoreOptions.scanFeatures;
 
 import java.io.File;
@@ -38,7 +38,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openengsb.labs.paxexam.karaf.options.LogLevelOption;
+import org.apache.karaf.tooling.exam.options.LogLevelOption;
 import org.ops4j.pax.exam.MavenUtils;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.Configuration;

--- a/itests/src/test/java/org/jclouds/karaf/itests/live/RackspaceLiveTest.java
+++ b/itests/src/test/java/org/jclouds/karaf/itests/live/RackspaceLiveTest.java
@@ -18,9 +18,9 @@
 package org.jclouds.karaf.itests.live;
 
 import static org.junit.Assert.assertTrue;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.debugConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.logLevel;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.debugConfiguration;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.logLevel;
 import static org.ops4j.pax.exam.CoreOptions.scanFeatures;
 
 import org.jclouds.compute.ComputeService;
@@ -28,7 +28,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openengsb.labs.paxexam.karaf.options.LogLevelOption;
+import org.apache.karaf.tooling.exam.options.LogLevelOption;
 import org.ops4j.pax.exam.MavenUtils;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.Configuration;

--- a/itests/src/test/java/org/jclouds/karaf/itests/special/JcloudsCamelCxfFeaturesTestSupport.java
+++ b/itests/src/test/java/org/jclouds/karaf/itests/special/JcloudsCamelCxfFeaturesTestSupport.java
@@ -17,15 +17,15 @@
 
 package org.jclouds.karaf.itests.special;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.logLevel;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.replaceConfigurationFile;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.logLevel;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.replaceConfigurationFile;
 
 import java.io.File;
 
 import org.jclouds.karaf.itests.live.AwsEc2LiveTest;
 import org.junit.Before;
-import org.openengsb.labs.paxexam.karaf.options.LogLevelOption;
+import org.apache.karaf.tooling.exam.options.LogLevelOption;
 import org.ops4j.pax.exam.MavenUtils;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.Configuration;

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@ limitations under the License.
     <felix.configadmin.version>1.2.8</felix.configadmin.version>
     <groovy.version>1.8.6</groovy.version>
     <gson.version>2.2.2</gson.version>
-    <guava.version>15.0</guava.version>
+    <guava.version>16.0</guava.version>
     <guava.test.version>10.0</guava.test.version>
     <guice.version>3.0</guice.version>
     <httpclient.version>4.1.1</httpclient.version>
@@ -204,12 +204,11 @@ limitations under the License.
     <junit.version>4.8.2</junit.version>
     <jzlib.bundle.version>1.0.7_1</jzlib.bundle.version>
     <jzlib.version>1.0.7</jzlib.version>
-    <karaf.version>2.2.7</karaf.version>
+    <karaf.version>2.3.2</karaf.version>
     <net.oauth.bundle.version>20100527_1</net.oauth.bundle.version>
     <netty.bundle.version>3.3.1.Final</netty.bundle.version>
-    <osgi.version>4.2.0</osgi.version>
-    <pax-exam-karaf.version>0.4.1</pax-exam-karaf.version>
-    <pax-exam.version>2.3.1</pax-exam.version>
+    <osgi.version>4.3.0</osgi.version>
+    <pax-exam.version>2.6.0</pax-exam.version>
     <pax-url-mvn.version>1.3.5</pax-url-mvn.version>
     <pax-url-aether.version>1.4.0.RC1</pax-url-aether.version>
     <rocoto.version>6.2</rocoto.version>
@@ -321,14 +320,6 @@ limitations under the License.
         <groupId>org.ops4j.pax.url</groupId>
         <artifactId>pax-url-aether</artifactId>
         <version>${pax-url-aether.version}</version>
-      </dependency>
-
-      <!-- Pax Exam Karaf -->
-      <dependency>
-        <groupId>org.openengsb.labs.paxexam.karaf</groupId>
-        <artifactId>paxexam-karaf-container</artifactId>
-        <version>${pax-exam-karaf.version}</version>
-        <scope>test</scope>
       </dependency>
 
       <dependency>
@@ -552,6 +543,18 @@ limitations under the License.
       <dependency>
         <groupId>org.apache.karaf.shell</groupId>
         <artifactId>org.apache.karaf.shell.console</artifactId>
+        <version>${karaf.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.karaf.tooling.exam</groupId>
+        <artifactId>org.apache.karaf.tooling.exam.options</artifactId>
+        <version>${karaf.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.karaf.tooling.exam</groupId>
+        <artifactId>org.apache.karaf.tooling.exam.container</artifactId>
         <version>${karaf.version}</version>
       </dependency>
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -77,14 +77,6 @@ limitations under the License.
       <groupId>org.apache.jclouds.driver</groupId>
       <artifactId>jclouds-sshj</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.compendium</artifactId>
-    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
This pull request upgrade to Karaf 2.3.2.
It explicitly specifies the features to be "verified" during build of the feature module.
Finally, it switches to Karaf's pax-exam support which has been moved from openengsb to Karaf as of 2.3.0.
