### PR TITLE
[JCLOUDS-225] Configured itests to use the generated repo.

### DIFF
--- a/itests/src/test/java/org/jclouds/karaf/itests/JcloudsFeaturesTestSupport.java
+++ b/itests/src/test/java/org/jclouds/karaf/itests/JcloudsFeaturesTestSupport.java
@@ -27,19 +27,9 @@ import org.ops4j.pax.exam.MavenUtils;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.Configuration;
 
+import java.io.File;
+
 public class JcloudsFeaturesTestSupport extends JcloudsKarafTestSupport {
-
-    public static final String JCLOUDS_FEATURE_FORMAT = "mvn:org.apache.jclouds.karaf/jclouds-karaf/%s/xml/features";
-    public static final String JCLOUDS_FEATURE_VERSION_PROPERTY =  "jclouds.feature.version";
-
-    /**
-     * Returns the URL of the jclouds-karaf feature.
-     * <p>Note: This method is intended to be invoked inside the test container</p>
-     * @return
-     */
-    public String getJcloudsKarafFeatureURL() {
-        return String.format(JCLOUDS_FEATURE_FORMAT, System.getProperty(JCLOUDS_FEATURE_VERSION_PROPERTY));
-    }
 
     /**
      * Installs a feature and checks that feature is properly installed.

--- a/itests/src/test/java/org/jclouds/karaf/itests/live/AwsEc2LiveTest.java
+++ b/itests/src/test/java/org/jclouds/karaf/itests/live/AwsEc2LiveTest.java
@@ -89,7 +89,7 @@ public class AwsEc2LiveTest extends JcloudsLiveTestSupport {
                 systemProperty("jclouds.aws.image"),
                 systemProperty("jclouds.aws.location"),
                 systemProperty("jclouds.aws.user"),
-                scanFeatures(String.format(JCLOUDS_FEATURE_FORMAT, MavenUtils.getArtifactVersion(JCLOUDS_KARAF_GROUP_ID, JCLOUDS_KARAF_ARTIFACT_ID)),"jclouds", "jclouds-compute", "jclouds-aws-ec2").start()
+                scanFeatures(getJcloudsKarafFeatureURL(),"jclouds", "jclouds-compute", "jclouds-aws-ec2").start()
         };
     }
 }

--- a/itests/src/test/java/org/jclouds/karaf/itests/live/AwsS3LiveTest.java
+++ b/itests/src/test/java/org/jclouds/karaf/itests/live/AwsS3LiveTest.java
@@ -161,8 +161,8 @@ public class AwsS3LiveTest extends JcloudsLiveTestSupport {
                 systemProperty("jclouds.aws.credential"),
                 systemProperty("jclouds.karaf.version",MavenUtils.getArtifactVersion(JCLOUDS_KARAF_GROUP_ID, JCLOUDS_KARAF_ARTIFACT_ID)),
                 systemProperty("jclouds.version",MavenUtils.getArtifactVersion(JCLOUDS_GROUP_ID, JCLOUDS_ARTIFACT_ID)),
-                systemProperty("jclouds.featureURL",String.format(JCLOUDS_FEATURE_FORMAT, MavenUtils.getArtifactVersion(JCLOUDS_KARAF_GROUP_ID, JCLOUDS_KARAF_ARTIFACT_ID))),
-                scanFeatures(String.format(JCLOUDS_FEATURE_FORMAT, MavenUtils.getArtifactVersion(JCLOUDS_KARAF_GROUP_ID, JCLOUDS_KARAF_ARTIFACT_ID)),"jclouds", "jclouds-commands", "jclouds-aws-s3").start()
+                systemProperty("jclouds.featureURL",getJcloudsKarafConfigFeatureURL()),
+                scanFeatures(String.format(MVN_JCLOUDS_FEATURE_FORMAT, MavenUtils.getArtifactVersion(JCLOUDS_KARAF_GROUP_ID, JCLOUDS_KARAF_ARTIFACT_ID)),"jclouds", "jclouds-commands", "jclouds-aws-s3").start()
         };
     }
 }

--- a/itests/src/test/java/org/jclouds/karaf/itests/live/CloudFilesUsLiveTest.java
+++ b/itests/src/test/java/org/jclouds/karaf/itests/live/CloudFilesUsLiveTest.java
@@ -161,8 +161,8 @@ public class CloudFilesUsLiveTest extends JcloudsLiveTestSupport {
                 systemProperty("jclouds.rackspace.credential"),
                 systemProperty("jclouds.karaf.version",MavenUtils.getArtifactVersion(JCLOUDS_KARAF_GROUP_ID, JCLOUDS_KARAF_ARTIFACT_ID)),
                 systemProperty("jclouds.version",MavenUtils.getArtifactVersion(JCLOUDS_GROUP_ID, JCLOUDS_ARTIFACT_ID)),
-                systemProperty("jclouds.featureURL",String.format(JCLOUDS_FEATURE_FORMAT, MavenUtils.getArtifactVersion(JCLOUDS_KARAF_GROUP_ID, JCLOUDS_KARAF_ARTIFACT_ID))),
-                scanFeatures(String.format(JCLOUDS_FEATURE_FORMAT, MavenUtils.getArtifactVersion(JCLOUDS_KARAF_GROUP_ID, JCLOUDS_KARAF_ARTIFACT_ID)),"jclouds", "jclouds-commands", "jclouds-cloudfiles-us").start()
+                systemProperty("jclouds.featureURL", getJcloudsKarafConfigFeatureURL()),
+                scanFeatures(String.format(MVN_JCLOUDS_FEATURE_FORMAT, MavenUtils.getArtifactVersion(JCLOUDS_KARAF_GROUP_ID, JCLOUDS_KARAF_ARTIFACT_ID)),"jclouds", "jclouds-commands", "jclouds-cloudfiles-us").start()
         };
     }
 }

--- a/itests/src/test/java/org/jclouds/karaf/itests/live/RackspaceLiveTest.java
+++ b/itests/src/test/java/org/jclouds/karaf/itests/live/RackspaceLiveTest.java
@@ -18,7 +18,6 @@
 package org.jclouds.karaf.itests.live;
 
 import static org.junit.Assert.assertTrue;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.debugConfiguration;
 import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
 import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.logLevel;
 import static org.ops4j.pax.exam.CoreOptions.scanFeatures;
@@ -90,7 +89,7 @@ public class RackspaceLiveTest extends JcloudsLiveTestSupport {
                 systemProperty("jclouds.rackspace.image"),
                 systemProperty("jclouds.rackspace.location"),
                 systemProperty("jclouds.rackspace.user"),
-                scanFeatures(String.format(JCLOUDS_FEATURE_FORMAT, MavenUtils.getArtifactVersion(JCLOUDS_KARAF_GROUP_ID, JCLOUDS_KARAF_ARTIFACT_ID)), "jclouds", "jclouds-compute", "jclouds-cloudserver-us").start()
+                scanFeatures(getJcloudsKarafConfigFeatureURL(), "jclouds", "jclouds-compute", "jclouds-cloudserver-us").start()
         };
     }
 }

--- a/itests/src/test/java/org/jclouds/karaf/itests/special/JcloudsCamelCxfFeaturesTestSupport.java
+++ b/itests/src/test/java/org/jclouds/karaf/itests/special/JcloudsCamelCxfFeaturesTestSupport.java
@@ -40,8 +40,8 @@ public class JcloudsCamelCxfFeaturesTestSupport extends AwsEc2LiveTest {
     @Before
     public void setUp() throws Exception {
         System.err.println(executeCommand("features:addurl " + String.format(CAMEL_FEATURE_FORMAT,System.getProperty(CAMEL_FEATURE_VERSION_PROPERTY))));
-        System.err.println(executeCommand("features:removeurl " + String.format(JCLOUDS_FEATURE_FORMAT, "1.3.1")));
-        System.err.println(executeCommand("features:addurl " + String.format(JCLOUDS_FEATURE_FORMAT,System.getProperty(JCLOUDS_FEATURE_VERSION_PROPERTY))));
+        System.err.println(executeCommand("features:removeurl " + String.format(MVN_JCLOUDS_FEATURE_FORMAT, "1.3.1")));
+        System.err.println(executeCommand("features:addurl " + String.format(MVN_JCLOUDS_FEATURE_FORMAT,System.getProperty(JCLOUDS_FEATURE_VERSION_PROPERTY))));
         System.err.println(executeCommand("features:install xml-specs-api"));
         System.err.println(executeCommand("osgi:install mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jsr250-1.0/1.9.0"));
         System.err.println(executeCommand("features:install camel-cxf"));


### PR DESCRIPTION
This pull request shows, how integration tests can use the generated features repository (generated by the feature module) so that they don't require the "install" goal when performing a full build.
