### PR TITLE
JCLOUDS-415: Upgrade to Guava 16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@ limitations under the License.
     <felix.configadmin.version>1.2.8</felix.configadmin.version>
     <groovy.version>1.8.6</groovy.version>
     <gson.version>2.2.2</gson.version>
-    <guava.version>15.0</guava.version>
+    <guava.version>16.0</guava.version>
     <guava.test.version>10.0</guava.test.version>
     <guice.version>3.0</guice.version>
     <httpclient.version>4.1.1</httpclient.version>


### PR DESCRIPTION
Release notes:

https://code.google.com/p/guava-libraries/wiki/Release16
