### PR TITLE
Upgrade to bouncycastle 1.49 to fix CVE-2013-1624

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@ limitations under the License.
 
   <properties>
     <aopalliance.bundle.version>1.0_5</aopalliance.bundle.version>
-    <bcprov.version>1.47</bcprov.version>
+    <bcprov.version>1.49</bcprov.version>
     <configadmin.version>1.2.8</configadmin.version>
     <easymock.version>3.0</easymock.version>
     <felix.configadmin.version>1.2.8</felix.configadmin.version>


### PR DESCRIPTION
Forward port of https://github.com/jclouds/jclouds-karaf/pull/31 to 1.7.x
