### PR TITLE
Adding <inceptionYear> 2009 to the top-level POM (1.7.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,10 @@ limitations under the License.
   <packaging>pom</packaging>
   <version>1.7.2-SNAPSHOT</version>
   <name>Apache jclouds :: Karaf</name>
-
-  <description>jclouds Karaf Integration Project</description>
   <url>http://jclouds.apache.org</url>
+  <description>jclouds Karaf Integration Project</description>
+  <inceptionYear>2009</inceptionYear>
+
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>


### PR DESCRIPTION
1.7.x version of https://github.com/jclouds/jclouds-karaf/pull/33
