### PR TITLE
[JCLOUDS-511] Correcting features with dependency-only bundles

### DIFF
--- a/feature/src/main/resources/feature.xml
+++ b/feature/src/main/resources/feature.xml
@@ -132,13 +132,12 @@ limitations under the License.
     <feature name="jclouds-api-rackspace-cloudidentity" description="Rackspace Cloud Identity API" version="${project.version}" resolver="(obr)">
         <feature version='${project.version}'>jclouds-compute</feature>
         <feature version='${project.version}'>jclouds-api-openstack-keystone</feature>
-        <bundle dependency='true'>mvn:org.apache.jclouds.api/rackspace-cloudidentity/${jclouds.version}</bundle>
+        <bundle>mvn:org.apache.jclouds.api/rackspace-cloudidentity/${jclouds.version}</bundle>
     </feature>
 
     <feature name="jclouds-api-rackspace-clouddns" description="Rackspace Cloud DNS API" version="${project.version}" resolver="(obr)">
         <feature version='${project.version}'>jclouds-api-rackspace-cloudidentity</feature>
-        <bundle dependency='true'>mvn:org.apache.jclouds.api/rackspace-clouddns/${jclouds.version}</bundle>
-
+        <bundle>mvn:org.apache.jclouds.api/rackspace-clouddns/${jclouds.version}</bundle>
     </feature>
 
     <feature name="jclouds-api-chef" description="Jclouds - API - Chef" version="${project.version}" resolver="(obr)">


### PR DESCRIPTION
Features which had only bundles with `dependency='true'` (they wouldn't install in Karaf):
- jclouds-api-rackspace-cloudidentity
- jclouds-api-rackspace-clouddns
