### PR TITLE
Using the jclouds version for Chef, rather than the project version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@ limitations under the License.
     <java-xmlbuilder.bundle.version>0.3_1</java-xmlbuilder.bundle.version>
     <javax.inject.bundle.version>1_1</javax.inject.bundle.version>
     <jclouds.version>1.8.0-SNAPSHOT</jclouds.version>
-    <jclouds.chef.version>${project.version}</jclouds.chef.version>
+    <jclouds.chef.version>${jclouds.version}</jclouds.chef.version>
     <jersey.version>1.11</jersey.version>
     <jersey.bundle.version>1.11_1</jersey.bundle.version>
     <joda.version>2.1</joda.version>


### PR DESCRIPTION
During releases, the reference should be to the released version of jclouds and jclouds-chef
