### PR TITLE
Do not cache System.out in commands.

### DIFF
--- a/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobListCommand.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobListCommand.java
@@ -46,8 +46,6 @@ public class BlobListCommand extends BlobStoreCommandWithOptions {
    @Argument(index = 1, name = "directoryPath", description = "List blobs only in this directory path", required = false)
    String directoryPath;
 
-   private static final PrintStream out = System.out;
-
    @Override
    protected Object doExecute() throws Exception {
       BlobStore blobStore = getBlobStore();
@@ -69,7 +67,7 @@ public class BlobListCommand extends BlobStoreCommandWithOptions {
 
          Collections.sort(blobNames);
          for (String blobName : blobNames) {
-            out.println(blobName);
+            System.out.println(blobName);
          }
 
          String marker = blobStoreMetadatas.getNextMarker();

--- a/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobMetadataCommand.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobMetadataCommand.java
@@ -45,8 +45,6 @@ public class BlobMetadataCommand extends BlobStoreCommandWithOptions {
    @Argument(index = 1, name = "blobNames", description = "The name of the blobs", required = true, multiValued = true)
    List<String> blobNames = Lists.newArrayList();
 
-   private static final PrintStream out = System.out;
-
    @Override
    protected Object doExecute() throws Exception {
       BlobStore blobStore = getBlobStore();
@@ -58,7 +56,7 @@ public class BlobMetadataCommand extends BlobStoreCommandWithOptions {
          }
 
          ContentMetadata contentMetdata = blobMetadata.getContentMetadata();
-         out.println(blobName + ":");
+         System.out.println(blobName + ":");
 
          printMetadata("Content-Disposition", contentMetdata.getContentDisposition());
          printMetadata("Content-Encoding", contentMetdata.getContentEncoding());
@@ -72,14 +70,14 @@ public class BlobMetadataCommand extends BlobStoreCommandWithOptions {
          printMetadata("Expires", contentMetdata.getExpires());
          printMetadata("Length", contentMetdata.getContentLength());
 
-         out.println("");
+         System.out.println("");
       }
       return null;
    }
 
    private static void printMetadata(String key, Object value) {
       if (value != null) {
-         out.println(String.format("    %s: %s", key, value));
+         System.out.println(String.format("    %s: %s", key, value));
       }
    }
 }

--- a/commands/src/main/java/org/jclouds/karaf/commands/blobstore/ContainerMetadataCommand.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/blobstore/ContainerMetadataCommand.java
@@ -43,8 +43,6 @@ public class ContainerMetadataCommand extends BlobStoreCommandWithOptions {
    @Argument(index = 0, name = "containerName", description = "The name of the container", required = true, multiValued = true)
    final Collection<String> containerNames = Lists.newArrayList();
 
-   private static final PrintStream out = System.out;
-
    @Override
    protected Object doExecute() throws Exception {
       BlobStore blobStore = getBlobStore();
@@ -68,7 +66,7 @@ public class ContainerMetadataCommand extends BlobStoreCommandWithOptions {
    }
 
    private static void printContainerMetadata(StorageMetadata containerMetadata) {
-      out.println(containerMetadata.getName());
+      System.out.println(containerMetadata.getName());
       printMetadata("ETag", containerMetadata.getETag());
       printMetadata("Creation-Date", containerMetadata.getCreationDate());
       printMetadata("Last-Modified", containerMetadata.getLastModified());
@@ -81,12 +79,12 @@ public class ContainerMetadataCommand extends BlobStoreCommandWithOptions {
       for (Map.Entry<String, String> entry : containerMetadata.getUserMetadata().entrySet()) {
          printMetadata(entry.getKey(), entry.getValue());
       }
-      out.println("");
+      System.out.println("");
    }
 
    private static void printMetadata(String key, Object value) {
       if (value != null) {
-         out.println(String.format("    %s: %s", key, value));
+         System.out.println(String.format("    %s: %s", key, value));
       }
    }
 }


### PR DESCRIPTION
If the System.out object is cached, callers that have invoked
System.setOut will observe that the new stream is not used and the
original file descriptor continues to be used by jclouds-karaf
commands.
