### PR TITLE
Removing duplicate jclouds-log4j driver dependency

### DIFF
--- a/commands/pom.xml
+++ b/commands/pom.xml
@@ -115,10 +115,6 @@ limitations under the License.
       <artifactId>jclouds-blobstore</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.jclouds.driver</groupId>
-      <artifactId>jclouds-log4j</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.jclouds.api</groupId>
       <artifactId>ec2</artifactId>
     </dependency>


### PR DESCRIPTION
Causes a warning in the build logs
