### PR TITLE
JCLOUDS-635 Always check for container existence before uploading blobs.

### DIFF
--- a/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobStoreCommandBase.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobStoreCommandBase.java
@@ -155,6 +155,11 @@ public abstract class BlobStoreCommandBase extends AbstractAction {
     * @param options
     */
    public void write(BlobStore blobStore, String bucket, String blobName, Blob blob, PutOptions options, boolean signedRequest) throws Exception {
+      if (!blobStore.containerExists(bucket)) {
+         throw new ContainerNotFoundException(bucket, "Container " + bucket
+               + " should exist before uploading blobs");
+      }
+
       if (blobName.contains("/")) {
          String directory = BlobStoreUtils.parseDirectoryFromPath(blobName);
          if (!Strings.isNullOrEmpty(directory)) {


### PR DESCRIPTION
This guarantees that the same error code is returned for all cloud providers
if the container does not exist.

Fixes #635.