### PR TITLE
Remove references to specific Chef versions

### DIFF
--- a/chef/cache/pom.xml
+++ b/chef/cache/pom.xml
@@ -36,7 +36,7 @@ limitations under the License.
     <osgi.export>org.jclouds.karaf.chef.cache;version=${project.version};-noimport:=true</osgi.export>
     <osgi.export.service>org.jclouds.karaf.cache.CacheProvider</osgi.export.service>
     <osgi.import>
-      org.jclouds.chef*;version=${jclouds.chef.version},
+      org.jclouds.chef*;version=${jclouds.version},
       org.jclouds.karaf.cache*,
       org.jclouds*;version=${jclouds.version},
       *

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,6 @@ limitations under the License.
     <java-xmlbuilder.bundle.version>0.3_1</java-xmlbuilder.bundle.version>
     <javax.inject.bundle.version>1_1</javax.inject.bundle.version>
     <jclouds.version>1.8.0-SNAPSHOT</jclouds.version>
-    <jclouds.chef.version>${jclouds.version}</jclouds.chef.version>
     <jersey.version>1.11</jersey.version>
     <jersey.bundle.version>1.11_1</jersey.bundle.version>
     <joda.version>2.1</joda.version>
@@ -546,7 +545,7 @@ limitations under the License.
       <dependency>
         <groupId>org.apache.jclouds.api</groupId>
         <artifactId>chef</artifactId>
-        <version>${jclouds.chef.version}</version>
+        <version>${jclouds.version}</version>
       </dependency>
 
       <!-- Karaf Dependencies -->


### PR DESCRIPTION
Note this is _not_ needed for 1.8 even if Chef has been merged to the main repo. Can be merged later.
