### PR TITLE
Add openstack-swift to jclouds-karaf.

### DIFF
--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -159,6 +159,7 @@ limitations under the License.
                 <feature>jclouds-skalicloud-sdg-my</feature>
                 <feature>jclouds-softlayer</feature>
                 <feature>jclouds-digitalocean</feature>
+                <feature>jclouds-openstack-swift</feature>
               </features>
               <repository>target/features-repo</repository>
             </configuration>

--- a/feature/src/main/resources/feature.xml
+++ b/feature/src/main/resources/feature.xml
@@ -80,6 +80,11 @@ limitations under the License.
         <bundle>mvn:org.apache.jclouds.api/byon/${jclouds.version}</bundle>
     </feature>
 
+    <feature name='jclouds-openstack-swift' description='jclouds - Openstack - Swift' version='${project.version}' resolver='(obr)'>
+        <feature version='${project.version}'>jclouds-compute</feature>
+        <bundle>mvn:org.apache.jclouds.labs/openstack-swift/${jclouds.version}</bundle>
+    </feature>
+
     <feature name='jclouds-api-swift' description='jclouds - API - Swift' version='${project.version}' resolver='(obr)'>
         <feature version='${project.version}'>jclouds-blobstore</feature>
         <feature version='${project.version}'>jclouds-api-openstack-keystone</feature>


### PR DESCRIPTION
jclouds-karaf should support openstack-swift provider for a smoother
transition of jclouds-cli/karaf consumers to 2.0.

Fixes: #669
