### PR TITLE
Upgrade to Gson 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@ limitations under the License.
     <easymock.version>3.0</easymock.version>
     <felix.configadmin.version>1.2.8</felix.configadmin.version>
     <groovy.version>1.8.6</groovy.version>
-    <gson.version>2.2.2</gson.version>
+    <gson.version>2.3</gson.version>
     <guava.version>18.0</guava.version>
     <guava.test.version>10.0</guava.test.version>
     <guice.version>3.0</guice.version>


### PR DESCRIPTION
This PR updates Gson to version 2.3 as per https://issues.apache.org/jira/browse/JCLOUDS-719
