### PR TITLE
Updating jsch.agentproxy 0.0.7 -> 0.0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,8 +201,8 @@ limitations under the License.
     <jersey.bundle.version>1.11_1</jersey.bundle.version>
     <joda.version>2.1</joda.version>
     <jsch.bundle.version>0.1.44_2</jsch.bundle.version>
-    <jsch.agentproxy.version>0.0.7</jsch.agentproxy.version>
-    <jsch.agentproxy.bundle.version>${jsch.agentproxy.version}_2</jsch.agentproxy.bundle.version>
+    <jsch.agentproxy.version>0.0.8</jsch.agentproxy.version>
+    <jsch.agentproxy.bundle.version>${jsch.agentproxy.version}_1</jsch.agentproxy.bundle.version>
     <jsr305.bundle.version>1.3.9_1</jsr305.bundle.version>
     <sericemix.specs.jsr250.version>1.9.0</sericemix.specs.jsr250.version>
     <junit.version>4.8.2</junit.version>


### PR DESCRIPTION
See https://github.com/jclouds/jclouds/pull/533. This is blocked (and will likely fail for now due to a missing dep) on the ServiceMix bundle push:

http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22org.apache.servicemix.bundles.jsch-agentproxy-sshj%22
