### PR TITLE
Removed the uses of the old ChefContext

### DIFF
--- a/chef/cache/src/main/java/org/jclouds/karaf/chef/cache/Activator.java
+++ b/chef/cache/src/main/java/org/jclouds/karaf/chef/cache/Activator.java
@@ -17,15 +17,19 @@
 
 package org.jclouds.karaf.chef.cache;
 
+import org.jclouds.chef.ChefApi;
 import org.jclouds.chef.ChefService;
 import org.jclouds.karaf.cache.BasicCacheProvider;
 import org.jclouds.karaf.cache.CacheManager;
 import org.jclouds.karaf.cache.CacheProvider;
 import org.jclouds.karaf.cache.utils.CacheUtils;
+import org.jclouds.rest.ApiContext;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.util.tracker.ServiceTracker;
+
+import com.google.common.reflect.TypeToken;
 
 import java.util.Hashtable;
 import java.util.Properties;
@@ -37,7 +41,7 @@ public class Activator implements BundleActivator {
 
     private ServiceRegistration cacheProviderRegistration;
 
-    private final CacheManager<ChefService> chefCacheManager = new CacheManager<ChefService>();
+    private final CacheManager<ApiContext<ChefApi>> chefCacheManager = new CacheManager<ApiContext<ChefApi>>();
 
 
     /**
@@ -61,7 +65,9 @@ public class Activator implements BundleActivator {
         cacheProviderRegistration = context.registerService(CacheProvider.class.getName(), cacheProvider, new Hashtable<String, Object>());
 
 
-        chefServiceTracker = CacheUtils.createServiceCacheTracker(context, ChefService.class, chefCacheManager);
+        chefServiceTracker = CacheUtils.createServiceCacheTracker(context, new TypeToken<ApiContext<ChefApi>>() {
+           private static final long serialVersionUID = 1L;
+        }, chefCacheManager);
         chefCacheableTracker = CacheUtils.createCacheableTracker(context, "jclouds.chefservice", chefCacheManager);
 
         chefServiceTracker.open();

--- a/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefCommandWithOptions.java
+++ b/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefCommandWithOptions.java
@@ -17,14 +17,13 @@
 
 package org.jclouds.karaf.chef.commands;
 
-import com.google.common.base.Strings;
-import org.apache.felix.gogo.commands.Option;
-import org.jclouds.apis.Apis;
-import org.jclouds.chef.ChefService;
-import org.jclouds.karaf.chef.core.ChefHelper;
-
 import java.util.Collections;
 import java.util.List;
+
+import org.apache.felix.gogo.commands.Option;
+import org.jclouds.chef.ChefApi;
+import org.jclouds.karaf.chef.core.ChefHelper;
+import org.jclouds.rest.ApiContext;
 
 public abstract class ChefCommandWithOptions extends ChefCommandBase {
 
@@ -50,12 +49,12 @@ public abstract class ChefCommandWithOptions extends ChefCommandBase {
     protected String endpoint;
 
     @Override
-    public List<ChefService> getChefServices() {
+    public List<ApiContext<ChefApi>> getChefServices() {
         if (api == null) {
             return chefServices;
         } else {
             try {
-                ChefService service = getChefService();
+               ApiContext<ChefApi> service = getChefService();
                 return Collections.singletonList(service);
             } catch (Throwable t) {
                 return Collections.emptyList();
@@ -63,7 +62,7 @@ public abstract class ChefCommandWithOptions extends ChefCommandBase {
         }
     }
 
-    protected ChefService getChefService() {
+    protected ApiContext<ChefApi> getChefService() {
         return ChefHelper.findOrCreateChefService(api, name, clientName,null, clientKeyFile, validatorName, null, validatorKeyFile, endpoint, chefServices);
     }
 }

--- a/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefCookbookListCommand.java
+++ b/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefCookbookListCommand.java
@@ -18,21 +18,22 @@
 package org.jclouds.karaf.chef.commands;
 
 import org.apache.felix.gogo.commands.Command;
-import org.jclouds.chef.ChefService;
+import org.jclouds.chef.ChefApi;
+import org.jclouds.rest.ApiContext;
 
 @Command(scope = "chef", name = "cookbook-list", description = "Lists the Chef Cook Books")
 public class ChefCookbookListCommand extends ChefCommandWithOptions {
 
     @Override
     protected Object doExecute() throws Exception {
-        ChefService service = null;
+       ApiContext<ChefApi> service = null;
         try {
             service = getChefService();
         } catch (Throwable t) {
             System.err.println(t.getMessage());
             return null;
         }
-        printCookbooks(service, service.listCookbookVersions(), System.out);
+        printCookbooks(service, service.getApi().chefService().listCookbookVersions(), System.out);
         return null;
     }
 }

--- a/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefGroupBootStrap.java
+++ b/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefGroupBootStrap.java
@@ -57,7 +57,7 @@ public class ChefGroupBootStrap extends ChefRunscriptBase {
     @Override
     public Statement getStatement() {
         Statement statement = null;
-        ChefService chefService = getChefService();
+        ChefService chefService = getChefService().getApi().chefService();
         if (chefService != null) {
             List<String> runlist = new RunListBuilder().addRecipes(cookbook).build();
             BootstrapConfig bootstrapConfig = BootstrapConfig.builder().runList(runlist).build();

--- a/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefNodeBootstrap.java
+++ b/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefNodeBootstrap.java
@@ -57,7 +57,7 @@ public class ChefNodeBootstrap extends ChefRunscriptBase {
     @Override
     public Statement getStatement() {
         Statement statement = null;
-        ChefService chefService = getChefService();
+        ChefService chefService = getChefService().getApi().chefService();
         if (chefService != null) {
             List<String> runlist = new RunListBuilder().addRecipes(cookbook).build();
             BootstrapConfig bootstrapConfig = BootstrapConfig.builder().runList(runlist).build();

--- a/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefRunscriptBase.java
+++ b/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefRunscriptBase.java
@@ -17,12 +17,13 @@
 
 package org.jclouds.karaf.chef.commands;
 
+import java.util.List;
+
 import org.apache.felix.gogo.commands.Option;
-import org.jclouds.chef.ChefService;
+import org.jclouds.chef.ChefApi;
 import org.jclouds.karaf.chef.core.ChefHelper;
 import org.jclouds.karaf.commands.compute.RunScriptBase;
-
-import java.util.List;
+import org.jclouds.rest.ApiContext;
 
 public abstract class ChefRunscriptBase extends RunScriptBase {
 
@@ -47,17 +48,17 @@ public abstract class ChefRunscriptBase extends RunScriptBase {
     @Option(name = "--chef-endpoint", description = "The endpoint to use for a chef service.")
     protected String chefEndpoint;
 
-    protected List<ChefService> chefServices;
+    protected List<ApiContext<ChefApi>> chefServices;
 
-    protected ChefService getChefService() {
+    protected ApiContext<ChefApi> getChefService() {
         return ChefHelper.findOrCreateChefService(chefApi, chefName, clientName, null, clientKeyFile, validatorName, null, validatorKeyFile, endpoint, chefServices);
     }
 
-    public List<ChefService> getChefServices() {
+    public List<ApiContext<ChefApi>> getChefServices() {
         return chefServices;
     }
 
-    public void setChefServices(List<ChefService> chefServices) {
+    public void setChefServices(List<ApiContext<ChefApi>> chefServices) {
         this.chefServices = chefServices;
     }
 

--- a/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefServiceCreateCommand.java
+++ b/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefServiceCreateCommand.java
@@ -20,10 +20,11 @@ package org.jclouds.karaf.chef.commands;
 import org.apache.felix.gogo.commands.Command;
 import org.apache.felix.gogo.commands.Option;
 import org.jclouds.apis.Apis;
-import org.jclouds.chef.ChefService;
+import org.jclouds.chef.ChefApi;
 import org.jclouds.karaf.chef.core.ChefConstants;
 import org.jclouds.karaf.chef.core.ChefHelper;
 import org.jclouds.karaf.core.Constants;
+import org.jclouds.rest.ApiContext;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.cm.Configuration;
@@ -179,20 +180,20 @@ public class ChefServiceCreateCommand extends ChefCommandWithOptions {
      * @param api
      * @return
      */
-    public synchronized ChefService waitForChefService(BundleContext bundleContext, String name, String api) {
-        ChefService chefService = null;
+    public synchronized ApiContext<ChefApi> waitForChefService(BundleContext bundleContext, String name, String api) {
+       ApiContext<ChefApi> chefService = null;
         try {
             for (int r = 0; r < 6; r++) {
                 ServiceReference[] references = null;
                 if (name != null) {
-                    references = bundleContext.getAllServiceReferences(ChefService.class.getName(), "(" + Constants.NAME + "="
+                    references = bundleContext.getAllServiceReferences(ApiContext.class.getName(), "(" + Constants.NAME + "="
                             + name + ")");
                 } else if (api != null) {
-                    references = bundleContext.getAllServiceReferences(ChefService.class.getName(), "(" + Constants.API + "=" + api + ")");
+                    references = bundleContext.getAllServiceReferences(ApiContext.class.getName(), "(" + Constants.API + "=" + api + ")");
                 }
 
                 if (references != null && references.length > 0) {
-                    chefService = (ChefService) bundleContext.getService(references[0]);
+                    chefService = (ApiContext<ChefApi>) bundleContext.getService(references[0]);
                     return chefService;
                 }
                 Thread.sleep(10000L);

--- a/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefServiceListCommand.java
+++ b/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/ChefServiceListCommand.java
@@ -17,10 +17,10 @@
 
 package org.jclouds.karaf.chef.commands;
 
-import com.google.common.reflect.TypeToken;
+import static org.jclouds.karaf.chef.core.ChefHelper.CHEF_TOKEN;
+
 import org.apache.felix.gogo.commands.Command;
 import org.jclouds.apis.Apis;
-import org.jclouds.chef.ChefContext;
 
 @Command(scope = "chef", name = "service-list", description = "Lists the Chef Services")
 public class ChefServiceListCommand extends ChefCommandBase {
@@ -30,7 +30,7 @@ public class ChefServiceListCommand extends ChefCommandBase {
         try {
             System.out.println("Chef APIs:");
             System.out.println("-------------");
-            printChefApis(Apis.contextAssignableFrom(TypeToken.of(ChefContext.class)), getChefServices(), System.out);
+            printChefApis(Apis.contextAssignableFrom(CHEF_TOKEN), getChefServices(), System.out);
         } catch (Exception ex) {
             // noop
         }

--- a/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/completer/ChefApiCompleter.java
+++ b/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/completer/ChefApiCompleter.java
@@ -17,20 +17,21 @@
 
 package org.jclouds.karaf.chef.commands.completer;
 
-import com.google.common.reflect.TypeToken;
+import static org.jclouds.karaf.chef.core.ChefHelper.CHEF_TOKEN;
+
+import java.util.List;
+
 import org.apache.karaf.shell.console.Completer;
 import org.apache.karaf.shell.console.completer.StringsCompleter;
 import org.jclouds.apis.ApiMetadata;
 import org.jclouds.apis.Apis;
-import org.jclouds.chef.ChefContext;
-import org.jclouds.chef.ChefService;
-
-import java.util.List;
+import org.jclouds.chef.ChefApi;
+import org.jclouds.rest.ApiContext;
 
 public class ChefApiCompleter implements Completer {
 
     private final StringsCompleter delegate = new StringsCompleter();
-    private List<? extends ChefService> chefServices;
+    private List<ApiContext<ChefApi>> chefServices;
 
     private final boolean displayApisWithoutService;
 
@@ -42,12 +43,12 @@ public class ChefApiCompleter implements Completer {
     public int complete(String buffer, int cursor, List<String> candidates) {
         try {
             if (displayApisWithoutService) {
-                for (ApiMetadata apiMetadata : Apis.contextAssignableFrom(TypeToken.of(ChefContext.class))) {
+                for (ApiMetadata apiMetadata : Apis.contextAssignableFrom(CHEF_TOKEN)) {
                     delegate.getStrings().add(apiMetadata.getId());
                 }
             } else if (chefServices != null) {
-                for (ChefService chefService : chefServices) {
-                    String api = chefService.getContext().unwrap().getId();
+                for (ApiContext<ChefApi> ctx : chefServices) {
+                    String api = ctx.getId();
                     if (Apis.withId(api) != null) {
                         delegate.getStrings().add(api);
                     }
@@ -59,11 +60,12 @@ public class ChefApiCompleter implements Completer {
         return delegate.complete(buffer, cursor, candidates);
     }
 
-    public List<? extends ChefService> getChefServices() {
+    public List<ApiContext<ChefApi>> getChefServices() {
         return chefServices;
     }
 
-    public void setChefServices(List<? extends ChefService> chefServices) {
+    public void setChefServices(List<ApiContext<ChefApi>> chefServices) {
         this.chefServices = chefServices;
     }
+
 }

--- a/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/completer/ChefCompleterSupport.java
+++ b/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/completer/ChefCompleterSupport.java
@@ -17,13 +17,14 @@
 
 package org.jclouds.karaf.chef.commands.completer;
 
-import org.jclouds.chef.ChefService;
+import org.jclouds.chef.ChefApi;
 import org.jclouds.karaf.commands.support.GenericCompleterSupport;
+import org.jclouds.rest.ApiContext;
 
-public abstract class ChefCompleterSupport extends GenericCompleterSupport<ChefService, String> {
+public abstract class ChefCompleterSupport extends GenericCompleterSupport<ApiContext<ChefApi>, String> {
 
     @Override
-    public String getCacheableKey(ChefService type) {
-        return type.getContext().unwrap().getName();
+    public String getCacheableKey(ApiContext<ChefApi> type) {
+        return type.getName();
     }
 }

--- a/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/completer/ChefContextNameCompleter.java
+++ b/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/completer/ChefContextNameCompleter.java
@@ -17,23 +17,24 @@
 
 package org.jclouds.karaf.chef.commands.completer;
 
+import java.util.List;
+
 import org.apache.karaf.shell.console.Completer;
 import org.apache.karaf.shell.console.completer.StringsCompleter;
-import org.jclouds.chef.ChefService;
-
-import java.util.List;
+import org.jclouds.chef.ChefApi;
+import org.jclouds.rest.ApiContext;
 
 public class ChefContextNameCompleter implements Completer {
 
     private final StringsCompleter delegate = new StringsCompleter();
-    private List<? extends ChefService> chefServices;
+    private List<ApiContext<ChefApi>> chefServices;
 
     @Override
     public int complete(String buffer, int cursor, List<String> candidates) {
         try {
             if (chefServices != null) {
-                for (ChefService chefService : chefServices) {
-                    String contextName = (String) chefService.getContext().unwrap().getName();
+                for (ApiContext<ChefApi> ctx : chefServices) {
+                    String contextName = ctx.getName();
                     if (contextName != null) {
                         delegate.getStrings().add(contextName);
                     }
@@ -45,11 +46,11 @@ public class ChefContextNameCompleter implements Completer {
         return delegate.complete(buffer, cursor, candidates);
     }
 
-    public List<? extends ChefService> getChefServices() {
+    public List<ApiContext<ChefApi>> getChefServices() {
         return chefServices;
     }
 
-    public void setChefServices(List<? extends ChefService> chefServices) {
+    public void setChefServices(List<ApiContext<ChefApi>> chefServices) {
         this.chefServices = chefServices;
     }
 }

--- a/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/completer/CookbookCompleter.java
+++ b/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/completer/CookbookCompleter.java
@@ -33,7 +33,7 @@ public class CookbookCompleter extends ChefCompleterSupport implements Completer
     @Override
     public void updateOnAdded(ApiContext<ChefApi> chefService) {
         if (chefService != null) {
-         Iterable<? extends CookbookVersion> cookbookVersions = chefService.getApi().chefService()
+            Iterable<? extends CookbookVersion> cookbookVersions = chefService.getApi().chefService()
                .listCookbookVersions();
             if (cookbookVersions != null) {
                 for (CookbookVersion cookbookVersion : cookbookVersions) {

--- a/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/completer/CookbookCompleter.java
+++ b/chef/commands/src/main/java/org/jclouds/karaf/chef/commands/completer/CookbookCompleter.java
@@ -18,10 +18,11 @@
 package org.jclouds.karaf.chef.commands.completer;
 
 import org.apache.karaf.shell.console.Completer;
-import org.jclouds.chef.ChefService;
+import org.jclouds.chef.ChefApi;
 import org.jclouds.chef.domain.CookbookVersion;
 import org.jclouds.karaf.chef.core.ChefConstants;
 import org.jclouds.karaf.utils.ServiceHelper;
+import org.jclouds.rest.ApiContext;
 
 public class CookbookCompleter extends ChefCompleterSupport implements Completer {
 
@@ -30,9 +31,10 @@ public class CookbookCompleter extends ChefCompleterSupport implements Completer
     }
 
     @Override
-    public void updateOnAdded(ChefService chefService) {
+    public void updateOnAdded(ApiContext<ChefApi> chefService) {
         if (chefService != null) {
-            Iterable<? extends CookbookVersion> cookbookVersions = chefService.listCookbookVersions();
+         Iterable<? extends CookbookVersion> cookbookVersions = chefService.getApi().chefService()
+               .listCookbookVersions();
             if (cookbookVersions != null) {
                 for (CookbookVersion cookbookVersion : cookbookVersions) {
                     for (String cacheKey : ServiceHelper.findCacheKeysForService(chefService)) {

--- a/chef/commands/src/main/resources/OSGI-INF/blueprint/jclouds-chef-commands.xml
+++ b/chef/commands/src/main/resources/OSGI-INF/blueprint/jclouds-chef-commands.xml
@@ -158,7 +158,7 @@ limitations under the License.
 
 
     <reference-list id="computeServices" interface="org.jclouds.compute.ComputeService" availability="optional"/>
-    <reference-list id="chefServices" interface="org.jclouds.chef.ChefService" availability="optional"/>
+    <reference-list id="chefServices" interface="org.jclouds.rest.ApiContext" availability="optional"/>
     <reference id="configAdmin" interface="org.osgi.service.cm.ConfigurationAdmin" availability="optional"/>
 
 </blueprint>

--- a/chef/core/src/main/java/org/jclouds/karaf/chef/core/ChefHelper.java
+++ b/chef/core/src/main/java/org/jclouds/karaf/chef/core/ChefHelper.java
@@ -17,26 +17,28 @@
 
 package org.jclouds.karaf.chef.core;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.google.common.io.Files;
-import com.google.inject.Module;
-import org.jclouds.ContextBuilder;
-import org.jclouds.apis.ApiMetadata;
-import org.jclouds.apis.Apis;
-import org.jclouds.chef.ChefContext;
-import org.jclouds.chef.ChefService;
-import org.jclouds.chef.config.ChefProperties;
-import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static com.google.common.base.Charsets.UTF_8;
 
 import java.io.File;
 import java.util.List;
 import java.util.Properties;
 
-import static com.google.common.base.Charsets.UTF_8;
+import org.jclouds.ContextBuilder;
+import org.jclouds.apis.ApiMetadata;
+import org.jclouds.apis.Apis;
+import org.jclouds.chef.ChefApi;
+import org.jclouds.chef.config.ChefProperties;
+import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
+import org.jclouds.rest.ApiContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.io.Files;
+import com.google.common.reflect.TypeToken;
+import com.google.inject.Module;
 
 public class ChefHelper {
 
@@ -50,6 +52,10 @@ public class ChefHelper {
     public static final String JCLOUDS_CHEF_VALIDATOR_KEY_FILE = "JCLOUDS_CHEF_VALIDATOR_KEY_FILE";
     public static final String JCLOUDS_CHEF_VALIDATOR_CREDENTIAL = "JCLOUDS_CHEF_VALIDATOR_CREDENTIAL";
     public static final String JCLOUDS_CHEF_ENDPOINT = "JCLOUDS_CHEF_ENDPOINT";
+    
+    public static final TypeToken<ApiContext<ChefApi>> CHEF_TOKEN = new TypeToken<ApiContext<ChefApi>>() {
+       private static final long serialVersionUID = 1L;
+    };
 
     private ChefHelper() {
         //Utility Class
@@ -169,19 +175,19 @@ public class ChefHelper {
 
 
     /**
-     * Chooses a {@link ChefService} that matches the specified a service id or a  api.
+     * Chooses a chef service that matches the specified a service id or a  api.
      *
      * @param id
      * @param api
      * @param services
      * @return
      */
-    public static ChefService getChefService(String id, String api, List<ChefService> services) {
+    public static ApiContext<ChefApi> getChefService(String id, String api, List<ApiContext<ChefApi>> services) {
         if (!Strings.isNullOrEmpty(id)) {
-            ChefService service = null;
-            for (ChefService svc : services) {
-                if (id.equals(svc.getContext().unwrap().getName())) {
-                    service = svc;
+           ApiContext<ChefApi> service = null;
+            for (ApiContext<ChefApi> ctx : services) {
+                if (id.equals(ctx.getName())) {
+                    service = ctx;
                     break;
                 }
             }
@@ -192,10 +198,10 @@ public class ChefHelper {
         }
 
         if (!Strings.isNullOrEmpty(api)) {
-            ChefService service = null;
-            for (ChefService svc : services) {
-                if (api.equals(svc.getContext().unwrap().getId())) {
-                    service = svc;
+           ApiContext<ChefApi> service = null;
+            for (ApiContext<ChefApi> ctx : services) {
+                if (api.equals(ctx.getId())) {
+                    service = ctx;
                     break;
                 }
             }
@@ -208,11 +214,11 @@ public class ChefHelper {
                 throw new IllegalArgumentException("No apis are present.  Note: It takes a couple of seconds for the provider to initialize.");
             } else if (services.size() != 1) {
                 StringBuilder sb = new StringBuilder();
-                for (ChefService svc : services) {
+                for (ApiContext<ChefApi> ctx : services) {
                     if (sb.length() > 0) {
                         sb.append(", ");
                     }
-                    sb.append(svc.getContext().unwrap().getName());
+                    sb.append(ctx.getName());
                 }
                 throw new IllegalArgumentException("Multiple apis are present, please select one using the--api argument in the following values: " + sb.toString());
             } else {
@@ -222,20 +228,22 @@ public class ChefHelper {
     }
 
     /**
-     * Creates a {@link ChefService} just by using Environmental variables.
+     * Creates a chef service just by using Environmental variables.
      *
      * @return
      */
-    public static ChefService createChefServiceFromEnvironment() {
-        return findOrCreateChefService(null, null, null, null, null, null, null, null, null, Lists.<ChefService>newArrayList());
+    public static ApiContext<ChefApi> createChefServiceFromEnvironment() {
+        return findOrCreateChefService(null, null, null, null, null, null, null, null, null, Lists.<ApiContext<ChefApi>>newArrayList());
     }
 
-    public static ChefService findOrCreateChefService(String api, String name, String clientName, String clientCredential, String clientKeyFile, String validatorName, String validatorCredential, String validatorKeyFile, String endpoint, List<ChefService> chefServices) {
+   public static ApiContext<ChefApi> findOrCreateChefService(String api, String name, String clientName,
+         String clientCredential, String clientKeyFile, String validatorName, String validatorCredential,
+         String validatorKeyFile, String endpoint, List<ApiContext<ChefApi>> chefServices) {
         if ((name == null && api == null) && (chefServices != null && chefServices.size() == 1)) {
             return chefServices.get(0);
         }
 
-        ChefService chefService = null;
+        ApiContext<ChefApi> ctx = null;
         String apiValue = ChefHelper.getChefApi(api);
         String clientNameValue = ChefHelper.getClientName(clientName);
         String clientCredentialValue = ChefHelper.getClientCredential(clientCredential);
@@ -253,7 +261,7 @@ public class ChefHelper {
         name = !Strings.isNullOrEmpty(name) ? name : apiValue;
 
         try {
-            chefService = ChefHelper.getChefService(name, apiValue, chefServices);
+            ctx = ChefHelper.getChefService(name, apiValue, chefServices);
         } catch (Throwable t) {
             if (contextNameProvided) {
                 throw new RuntimeException("Could not find chef service with id:" + name);
@@ -289,17 +297,19 @@ public class ChefHelper {
             }
         }
 
-        if (chefService == null && canCreateService) {
+        if (ctx == null && canCreateService) {
             try {
-                chefService = ChefHelper.createChefService(Apis.withId(apiValue), name, clientNameValue, clientCredentialValue, clientKeyFileValue, validatorNameValue, validatorCredentialValue, validatorKeyFileValue, endpointValue);
+                ctx = ChefHelper.createChefService(Apis.withId(apiValue), name, clientNameValue, clientCredentialValue, clientKeyFileValue, validatorNameValue, validatorCredentialValue, validatorKeyFileValue, endpointValue);
             } catch (Exception ex) {
                 throw new RuntimeException("Failed to create service:" + ex.getMessage());
             }
         }
-        return chefService;
+        return ctx;
     }
 
-    public static ChefService createChefService(ApiMetadata apiMetadata, String name, String clientName, String clientCredential, String clientKeyFile, String validatorName, String validatorCredential, String validatorKeyFile, String endpoint) throws Exception {
+   public static ApiContext<ChefApi> createChefService(ApiMetadata apiMetadata, String name, String clientName,
+         String clientCredential, String clientKeyFile, String validatorName, String validatorCredential,
+         String validatorKeyFile, String endpoint) throws Exception {
         if (Strings.isNullOrEmpty(clientName) && apiMetadata != null && !apiMetadata.getDefaultCredential().isPresent()) {
             LOGGER.warn("No client specified for api {}.", apiMetadata.getId());
             return null;
@@ -339,9 +349,7 @@ public class ChefHelper {
         builder = builder.name(name).credentials(clientName, clientCredential).overrides(chefConfig);
 
         // builder.build() does not compile on JDK 6
-        ChefContext context = builder.build(ChefContext.class);
-        ChefService service = context.getChefService();
-        return service;
+        return builder.build(CHEF_TOKEN);
     }
 
     /**

--- a/chef/core/src/main/java/org/jclouds/karaf/chef/core/ChefHelper.java
+++ b/chef/core/src/main/java/org/jclouds/karaf/chef/core/ChefHelper.java
@@ -184,7 +184,7 @@ public class ChefHelper {
      */
     public static ApiContext<ChefApi> getChefService(String id, String api, List<ApiContext<ChefApi>> services) {
         if (!Strings.isNullOrEmpty(id)) {
-           ApiContext<ChefApi> service = null;
+            ApiContext<ChefApi> service = null;
             for (ApiContext<ChefApi> ctx : services) {
                 if (id.equals(ctx.getName())) {
                     service = ctx;
@@ -198,7 +198,7 @@ public class ChefHelper {
         }
 
         if (!Strings.isNullOrEmpty(api)) {
-           ApiContext<ChefApi> service = null;
+            ApiContext<ChefApi> service = null;
             for (ApiContext<ChefApi> ctx : services) {
                 if (api.equals(ctx.getId())) {
                     service = ctx;
@@ -236,9 +236,9 @@ public class ChefHelper {
         return findOrCreateChefService(null, null, null, null, null, null, null, null, null, Lists.<ApiContext<ChefApi>>newArrayList());
     }
 
-   public static ApiContext<ChefApi> findOrCreateChefService(String api, String name, String clientName,
-         String clientCredential, String clientKeyFile, String validatorName, String validatorCredential,
-         String validatorKeyFile, String endpoint, List<ApiContext<ChefApi>> chefServices) {
+    public static ApiContext<ChefApi> findOrCreateChefService(String api, String name, String clientName,
+            String clientCredential, String clientKeyFile, String validatorName, String validatorCredential,
+            String validatorKeyFile, String endpoint, List<ApiContext<ChefApi>> chefServices) {
         if ((name == null && api == null) && (chefServices != null && chefServices.size() == 1)) {
             return chefServices.get(0);
         }

--- a/chef/services/pom.xml
+++ b/chef/services/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
   <name>jclouds :: Karaf :: Chef :: Services</name>
 
   <properties>
-    <osgi.import>*</osgi.import>
+    <osgi.import>org.jclouds.rest;version=${jclouds.version},*</osgi.import>
     <osgi.private>
       org.jclouds.karaf.chef.core*,
       org.jclouds.karaf.chef.services*

--- a/chef/services/src/main/java/org/jclouds/karaf/chef/services/ChefRecipeProvider.java
+++ b/chef/services/src/main/java/org/jclouds/karaf/chef/services/ChefRecipeProvider.java
@@ -18,11 +18,14 @@
 package org.jclouds.karaf.chef.services;
 
 import com.google.common.collect.Sets;
+
+import org.jclouds.chef.ChefApi;
 import org.jclouds.chef.ChefService;
 import org.jclouds.chef.domain.BootstrapConfig;
 import org.jclouds.chef.domain.CookbookVersion;
 import org.jclouds.chef.util.RunListBuilder;
 import org.jclouds.karaf.recipe.RecipeProvider;
+import org.jclouds.rest.ApiContext;
 import org.jclouds.scriptbuilder.domain.Statement;
 
 import java.util.List;
@@ -33,9 +36,9 @@ public class ChefRecipeProvider implements RecipeProvider {
     final ChefService chefService;
     final String id;
 
-    public ChefRecipeProvider(ChefService chefService) {
-        this.chefService = chefService;
-        this.id = chefService.getContext().unwrap().getName();
+    public ChefRecipeProvider(ApiContext<ChefApi> ctx) {
+        this.chefService = ctx.getApi().chefService();
+        this.id = ctx.getName();
     }
 
     @Override

--- a/chef/services/src/main/java/org/jclouds/karaf/chef/services/ChefServiceFactory.java
+++ b/chef/services/src/main/java/org/jclouds/karaf/chef/services/ChefServiceFactory.java
@@ -17,26 +17,29 @@
 
 package org.jclouds.karaf.chef.services;
 
-import com.google.common.base.Strings;
-import com.google.common.reflect.TypeToken;
+import static org.jclouds.karaf.chef.core.ChefHelper.CHEF_TOKEN;
+
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.Properties;
+
 import org.jclouds.apis.ApiMetadata;
 import org.jclouds.apis.ApiPredicates;
-import org.jclouds.chef.ChefContext;
-import org.jclouds.chef.ChefService;
+import org.jclouds.chef.ChefApi;
 import org.jclouds.karaf.chef.core.ChefConstants;
 import org.jclouds.karaf.chef.core.ChefHelper;
-import org.jclouds.karaf.services.ServiceFactorySupport;
 import org.jclouds.karaf.services.InvalidConfigurationException;
+import org.jclouds.karaf.services.ServiceFactorySupport;
 import org.jclouds.providers.ProviderMetadata;
+import org.jclouds.rest.ApiContext;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Dictionary;
-import java.util.Enumeration;
-import java.util.Properties;
+import com.google.common.base.Strings;
+import com.google.common.reflect.TypeToken;
 
 
 
@@ -91,9 +94,9 @@ public class ChefServiceFactory extends ServiceFactorySupport {
                 String validatorCredential = (String) properties.get(ChefConstants.VALIDATOR_CREDENTIAL);
                 String endpoint = (String) properties.get(ChefConstants.ENDPOINT);
 
-                ChefService service = ChefHelper.createChefService(apiMetadata, id, clientName, clientCredential, clientKeyFile, validatorName, validatorCredential, validatorKeyFile, endpoint);
+                ApiContext<ChefApi> service = ChefHelper.createChefService(apiMetadata, id, clientName, clientCredential, clientKeyFile, validatorName, validatorCredential, validatorKeyFile, endpoint);
                 newRegistration = bundleContext.registerService(
-                        ChefService.class.getName(), service, properties);
+                        ApiContext.class.getName(), service, properties);
 
                 //If all goes well remove the pending pid.
                 if (pendingPids.containsKey(pid)) {
@@ -143,6 +146,6 @@ public class ChefServiceFactory extends ServiceFactorySupport {
 
     @Override
     public boolean apply(ApiMetadata api) {
-        return ApiPredicates.contextAssignableFrom(TypeToken.of(ChefContext.class)).apply(api);
+       return ApiPredicates.contextAssignableFrom(CHEF_TOKEN).apply(api);
     }
 }

--- a/chef/services/src/main/java/org/jclouds/karaf/chef/services/EnvBasedChefRecipeProvider.java
+++ b/chef/services/src/main/java/org/jclouds/karaf/chef/services/EnvBasedChefRecipeProvider.java
@@ -17,16 +17,12 @@
 
 package org.jclouds.karaf.chef.services;
 
-import com.google.common.collect.Sets;
 import org.jclouds.chef.ChefService;
-import org.jclouds.chef.domain.CookbookVersion;
 import org.jclouds.karaf.chef.core.ChefHelper;
 import org.jclouds.karaf.recipe.RecipeProvider;
 
-import java.util.Set;
-
 /**
- * An implementation of {@link RecipeProvider} for a {@link ChefService} which is configured in environment.
+ * An implementation of {@link RecipeProvider} for a chef service which is configured in environment.
  */
 public class EnvBasedChefRecipeProvider extends ChefRecipeProvider implements RecipeProvider {
 


### PR DESCRIPTION
Refactored the Chef integration to get rid of the old `ChefContext` and use the `ApiContext<ChefApi>`. Instead of injecting the `ChefService` everywhere, it is more correct to inject directly the context that provides access to both the `ChefApi` and the `ChefService`.

Verified by running the CLI and creating different Chef services. Both can be individually referenced and commands can be run on each, so looks like all the caching stuff and everything is working as expected.

/cc @iocanel @ccustine 