### PR TITLE
JCLOUDS-897: Remove the Rocoto dependency

### DIFF
--- a/feature/src/main/resources/feature.xml
+++ b/feature/src/main/resources/feature.xml
@@ -23,7 +23,6 @@ limitations under the License.
         <bundle>mvn:com.google.inject/guice/${guice.version}</bundle>
         <bundle>mvn:com.google.inject.extensions/guice-assistedinject/${guice.version}</bundle>
         <bundle>mvn:com.google.inject.extensions/guice-multibindings/${guice.version}</bundle>
-        <bundle>mvn:org.99soft.guice/rocoto/${rocoto.version}</bundle>
     </feature>
 
     <feature name='jclouds' description='jclouds' version='${project.version}' resolver='(obr)'>

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,6 @@ limitations under the License.
     <pax-exam.version>2.6.0</pax-exam.version>
     <pax-url-mvn.version>1.3.5</pax-url-mvn.version>
     <pax-url-aether.version>1.4.0.RC1</pax-url-aether.version>
-    <rocoto.version>6.2</rocoto.version>
     <scripting.api.bundle.version>2.0.0</scripting.api.bundle.version>
     <slf4j.version>1.5.8</slf4j.version>
     <snakeyaml.version>1.11</snakeyaml.version>


### PR DESCRIPTION
Aligns karaf with: https://github.com/jclouds/jclouds/pull/738
(It is possible that the build fails until the snapshot dependencies have been populated to the repo)