### PR TITLE
Minimize Groovy dependency

### DIFF
--- a/chef/commands/pom.xml
+++ b/chef/commands/pom.xml
@@ -113,7 +113,7 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
+      <artifactId>groovy</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/commands/pom.xml
+++ b/commands/pom.xml
@@ -148,7 +148,7 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
+      <artifactId>groovy</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/feature/src/main/resources/feature.xml
+++ b/feature/src/main/resources/feature.xml
@@ -419,7 +419,8 @@ limitations under the License.
         <configfile finalname="/etc/org.apache.jclouds.shell.cfg">mvn:org.apache.jclouds.karaf/jclouds-karaf/${project.version}/cfg/shell</configfile>
         <feature version='${project.version}'>jclouds-services</feature>
         <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.scripting-api-1.0/${scripting.api.bundle.version}</bundle>
-        <bundle dependency="true">mvn:org.codehaus.groovy/groovy-all/${groovy.version}</bundle>
+        <bundle dependency="true">mvn:org.codehaus.groovy/groovy/${groovy.version}</bundle>
+        <bundle dependency="true">mvn:org.codehaus.groovy/groovy-jsr223/${groovy.version}</bundle>
         <bundle>mvn:org.apache.jclouds.karaf/core/${project.version}</bundle>
         <bundle>mvn:org.apache.jclouds.karaf/recipe/${project.version}</bundle>
         <bundle>mvn:org.apache.jclouds.karaf/commands/${project.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -437,7 +437,13 @@ limitations under the License.
       <!-- Groovy -->
       <dependency>
         <groupId>org.codehaus.groovy</groupId>
-        <artifactId>groovy-all</artifactId>
+        <artifactId>groovy</artifactId>
+        <version>${groovy.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.codehaus.groovy</groupId>
+        <artifactId>groovy-jsr223</artifactId>
         <version>${groovy.version}</version>
       </dependency>
 


### PR DESCRIPTION
This shrinks jclouds-cli from 28 MB to 26 MB.