### PR TITLE
JCLOUDS-1156: Shade the jsch-agentproxy-jsch bundle

### DIFF
--- a/bundles/jsch-agentproxy-jsch/pom.xml
+++ b/bundles/jsch-agentproxy-jsch/pom.xml
@@ -17,16 +17,16 @@ limitations under the License.
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>jclouds-karaf</artifactId>
     <groupId>org.apache.jclouds</groupId>
+    <artifactId>jclouds-karaf</artifactId>
     <version>2.0.0-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.apache.jclouds.karaf.bundles</groupId>
   <artifactId>jsch-agentproxy-jsch</artifactId>
-  <name>jclouds :: Karaf :: JSCH Agentproxy Shaded Bundle</name>
+  <name>jclouds :: Karaf :: JSch Agentproxy for JSch (shaded bundle)</name>
   <packaging>bundle</packaging>
 
   <dependencies>

--- a/bundles/jsch-agentproxy-jsch/pom.xml
+++ b/bundles/jsch-agentproxy-jsch/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>jclouds-karaf</artifactId>
+    <groupId>org.apache.jclouds</groupId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.jclouds.karaf.bundles</groupId>
+  <artifactId>jsch-agentproxy-jsch</artifactId>
+  <name>jclouds :: Karaf :: JSCH Agentproxy Shaded Bundle</name>
+  <packaging>bundle</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.servicemix.bundles</groupId>
+      <artifactId>org.apache.servicemix.bundles.jsch-agentproxy-jsch</artifactId>
+      <version>${jsch.agentproxy.bundle.version}</version>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <import.packages>
+      ft.jzlib;resolution:=optional;version="[1.1,2)",
+      keypairgen;resolution:=optional,
+      signature;resolution:=optional,
+      userauth;resolution:=optional,
+      org.ietf.jgss;resolution:=optional,
+      javax.crypto,
+      javax.crypto.interfaces,
+      javax.crypto.spec,
+      javax.naming, 
+      javax.naming.directory, 
+      javax.net, 
+      javax.security.auth.x500
+    </import.packages>
+  </properties>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+        <configuration>
+          <instructions>
+            <Import-Package>${import.packages}</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+              <artifactSet>
+                <includes>
+                  <include>org.apache.servicemix.bundles:org.apache.servicemix.bundles.jsch-agentproxy-jsch</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/bundles/jsch-agentproxy-jsch/pom.xml
+++ b/bundles/jsch-agentproxy-jsch/pom.xml
@@ -19,8 +19,8 @@ limitations under the License.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.jclouds</groupId>
-    <artifactId>jclouds-karaf</artifactId>
+    <groupId>org.apache.jclouds.karaf</groupId>
+    <artifactId>bundles</artifactId>
     <version>2.0.0-SNAPSHOT</version>
   </parent>
 

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>jclouds-karaf</artifactId>
+    <groupId>org.apache.jclouds</groupId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.jclouds.karaf</groupId>
+  <artifactId>shaded-bundles</artifactId>
+  <name>jclouds :: Karaf :: Bundles</name>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>jsch-agentproxy-jsch</module>
+  </modules>
+
+</project>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -17,15 +17,15 @@ limitations under the License.
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>jclouds-karaf</artifactId>
     <groupId>org.apache.jclouds</groupId>
+    <artifactId>jclouds-karaf</artifactId>
     <version>2.0.0-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.apache.jclouds.karaf</groupId>
-  <artifactId>shaded-bundles</artifactId>
+  <artifactId>bundles</artifactId>
   <name>jclouds :: Karaf :: Bundles</name>
   <packaging>pom</packaging>
 

--- a/feature/src/main/resources/feature.xml
+++ b/feature/src/main/resources/feature.xml
@@ -398,7 +398,7 @@ limitations under the License.
         <feature version='${project.version}'>jclouds-compute</feature>
         <feature version='${project.version}'>jclouds-blobstore</feature>
         <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jsch/${jsch.bundle.version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jsch-agentproxy-jsch/${jsch.agentproxy.bundle.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.jclouds.karaf.bundles/jsch-agentproxy-jsch/${project.version}</bundle>
         <bundle dependency='true'>mvn:com.jcraft/jsch.agentproxy.connector-factory/${jsch.agentproxy.version}</bundle>
         <bundle dependency='true'>mvn:com.jcraft/jsch.agentproxy.usocket-nc/${jsch.agentproxy.version}</bundle>
         <bundle dependency='true'>mvn:com.jcraft/jsch.agentproxy.sshagent/${jsch.agentproxy.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@ limitations under the License.
 
   <modules>
     <module>core</module>
+    <module>bundles</module>
     <module>utils</module>
     <module>cache</module>
     <module>commands</module>

--- a/pom.xml
+++ b/pom.xml
@@ -469,11 +469,6 @@ limitations under the License.
 
       <!-- JSch agentproxy -->
       <dependency>
-        <groupId>org.apache.servicemix.bundles</groupId>
-        <artifactId>org.apache.servicemix.bundles.jsch-agentproxy-jsch</artifactId>
-        <version>${jsch.agentproxy.bundle.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.jcraft</groupId>
         <artifactId>jsch.agentproxy.connector-factory</artifactId>
         <version>${jsch.agentproxy.version}</version>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/JCLOUDS-1156

I've shaded the offending bundle and shaded it to remove the invalid export. I did this by adding a `bundles` project where we can put our own bundles if we get into similar situations in the future.

With this fix, I've been able to properly register compute services, but there is an issue in the output of the commands. As you can see below, the commands are executed but produce no output. it actually fetches the results (each empty line is a result) but they are not printed. The same command run outside CLI shell produces a proper output.

@demobox Good to merge the exports fix? We can fix the output thing in an upcoming PR.
@ccustine @iocanel Could you give us some hint on what could be going on with the output of the commands?

```bash
jclouds> jclouds:compute-service-create --provider profitbricks --identity **** --credential **** --name pb
Waiting for compute service with name: pb.
jclouds> jclouds:compute-service-list
Compute APIs:
-------------
[id]                     [type]       [service]   
ec2                      compute      [ ]         
stub                     compute      [ ]         


Compute Providers:
------------------
[id]                     [type]       [service]   
aws-ec2                  compute      [ ]         
profitbricks             compute      [ pb ]
jclouds> jclouds:location-list --provider profitbricks --name pb
[id] [scope] [description] [parent]
                                   
                                   
                                   
                                   
                                   
                                   

$ ./jclouds location list --provider profitbricks --identity **** --credential ****
[id]         [scope]  [description]                    [parent]    
us/las       ZONE     us/las                           us          
us           REGION   us                               profitbricks
de           REGION   de                               profitbricks
de/fra       ZONE     de/fra                           de          
de/fkb       ZONE     de/fkb                           de          
profitbricks PROVIDER https://api.profitbricks.com/1.3             
us/lasdev    ZONE     us/lasdev                        us
```