### PR TITLE
JCLOUDS-1172: Explicitly fallback to the Groovy scripting engine

### DIFF
--- a/commands/pom.xml
+++ b/commands/pom.xml
@@ -151,6 +151,10 @@ limitations under the License.
       <artifactId>groovy</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-jsr223</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/commands/src/main/java/org/jclouds/karaf/commands/table/internal/ScriptEngineShellTable.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/table/internal/ScriptEngineShellTable.java
@@ -17,7 +17,11 @@
 
 package org.jclouds.karaf.commands.table.internal;
 
+import org.codehaus.groovy.jsr223.GroovyScriptEngineImpl;
+import org.jclouds.karaf.commands.blobstore.BlobStoreCommandBase;
 import org.jclouds.karaf.commands.table.BasicShellTable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
@@ -27,17 +31,21 @@ import javax.script.ScriptEngineManager;
  */
 public class ScriptEngineShellTable<D extends Object> extends BasicShellTable<D> {
 
-  private final String engine;
+  private static final Logger LOGGER = LoggerFactory.getLogger(ScriptEngineShellTable.class);
+   
   private final ScriptEngineManager scriptEngineFactory = new ScriptEngineManager();
-  private final ScriptEngine scriptEngine;
+  private ScriptEngine scriptEngine;
 
   /**
    * Constructor
    * @param engine
    */
   public ScriptEngineShellTable(String engine) {
-    this.engine = engine;
     this.scriptEngine = scriptEngineFactory.getEngineByName(engine);
+    if (scriptEngine == null) {
+       LOGGER.warn("Could not load a script engine for {}. Will fallback to Groovy", engine);
+       scriptEngine = new GroovyScriptEngineImpl();
+    }
   }
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/JCLOUDS-1172

Force the use of the default Groovy engine if the script engine factory can't load any scripting engine. See https://github.com/jclouds/jclouds-karaf/pull/77#issuecomment-244901813 for more details.
