### PR TITLE
Added Azure ARM

### DIFF
--- a/bundles/okhttp/pom.xml
+++ b/bundles/okhttp/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.jclouds.karaf</groupId>
+    <artifactId>bundles</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <!--
+    This is a bundle for the OkHttp library. Support for OSGi was added in OkHttp 3.0.0 but rolled back
+    in 3.0.1. Previous versions don't provide OSGi bundles.
+    To be removed once this is merged: https://github.com/apache/servicemix-bundles/pull/85
+  -->
+  <groupId>org.apache.jclouds.karaf.bundles</groupId>
+  <artifactId>okhttp</artifactId>
+  <name>jclouds :: Karaf :: OkHttp (shaded bundle)</name>
+  <packaging>bundle</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>${okhttp.version}</version>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <export.packages>com.squareup.okhttp*;version="${okhttp.version}"</export.packages>
+    <import.packages>*</import.packages>
+  </properties>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+        <configuration>
+          <instructions>
+            <Export-Package>${export.packages}</Export-Package>
+            <Import-Package>${import.packages}</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <!-- the RAT plugin complains if we use the default location and we don't want it in the SCM -->
+              <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+              <artifactSet>
+                <includes>
+                  <include>com.squareup.okhttp:okhttp</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/bundles/okio/pom.xml
+++ b/bundles/okio/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.jclouds.karaf</groupId>
+    <artifactId>bundles</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <!--
+    ServiceMix bundles for Okio start at version 1.6.0, but our current OkHttp driver uses OkHttp 2.2.0 that depends
+    on Okio 1.2.0.
+    To be removed once this is merged: https://github.com/apache/servicemix-bundles/pull/86
+  -->
+  <groupId>org.apache.jclouds.karaf.bundles</groupId>
+  <artifactId>okio</artifactId>
+  <name>jclouds :: Karaf :: Okio (shaded bundle)</name>
+  <packaging>bundle</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio</artifactId>
+      <version>${okio.version}</version>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <export.packages>okio*;version="${okio.version}"</export.packages>
+    <import.packages>*</import.packages>
+  </properties>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+        <configuration>
+          <instructions>
+            <Export-Package>${export.packages}</Export-Package>
+            <Import-Package>${import.packages}</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <!-- the RAT plugin complains if we use the default location and we don't want it in the SCM -->
+              <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+              <artifactSet>
+                <includes>
+                  <include>com.squareup.okio:okio</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -31,6 +31,8 @@ limitations under the License.
 
   <modules>
     <module>jsch-agentproxy-jsch</module>
+    <module>okio</module>
+    <module>okhttp</module>
   </modules>
 
 </project>

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -125,6 +125,7 @@ limitations under the License.
                 <feature>jclouds-aws-sqs</feature>
                 <feature>jclouds-aws-sts</feature>
                 <feature>jclouds-azureblob</feature>
+                <feature>jclouds-azurecompute-arm</feature>
                 <feature>jclouds-b2</feature>
                 <feature>jclouds-cloudsigma2-hnl</feature>
                 <feature>jclouds-cloudsigma2-lvs</feature>

--- a/feature/src/main/resources/feature.xml
+++ b/feature/src/main/resources/feature.xml
@@ -346,6 +346,16 @@ limitations under the License.
         <bundle>mvn:org.apache.jclouds.provider/google-compute-engine/${jclouds.version}</bundle>
     </feature>
 
+    <feature name='jclouds-azurecompute-arm' description='Components to access Azure Compute ARM' version='${project.version}' resolver='(obr)'>
+        <feature version='${project.version}'>jclouds-compute</feature>
+        <feature version='${project.version}'>jclouds-azureblob</feature>
+        <bundle dependency='true'>mvn:org.apache.jclouds.api/oauth/${jclouds.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.jclouds.karaf.bundles/okio/${project.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.jclouds.karaf.bundles/okhttp/${project.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.jclouds.driver/jclouds-okhttp/${jclouds.version}</bundle>
+        <bundle>mvn:org.apache.jclouds.labs/azurecompute-arm/${jclouds.version}</bundle>
+    </feature>
+
     <feature name='jclouds-profitbricks' description='Components to access ProfitBricks' version='${project.version}' resolver='(obr)'>
         <feature version='${project.version}'>jclouds-compute</feature>
         <bundle>mvn:org.apache.jclouds.provider/profitbricks/${jclouds.version}</bundle>

--- a/itests/src/test/java/org/jclouds/karaf/itests/MiscFeaturesInstallationTest.java
+++ b/itests/src/test/java/org/jclouds/karaf/itests/MiscFeaturesInstallationTest.java
@@ -85,6 +85,11 @@ public class MiscFeaturesInstallationTest extends JcloudsFeaturesTestSupport {
     }
 
     @Test
+    public void testAzureComputeArmFeature() throws Exception {
+        installAndCheckFeature("jclouds-azurecompute-arm");
+    }
+
+    @Test
     public void testDynectFeature() throws Exception {
         installAndCheckFeature("jclouds-dynect");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,8 @@ limitations under the License.
     <pax-url-aether.version>1.4.0.RC1</pax-url-aether.version>
     <slf4j.version>1.5.8</slf4j.version>
     <snakeyaml.version>1.11</snakeyaml.version>
+    <okhttp.version>2.2.0</okhttp.version>
+    <okio.version>1.2.0</okio.version>
 
     <!-- Plugin Versions -->
     <depends-maven-plugin.version>1.2</depends-maven-plugin.version>


### PR DESCRIPTION
This will allow to use the Azure ARM provider from the jclouds CLI (/cc @ritazh)

This PR depends on https://github.com/jclouds/jclouds-labs/pull/318 and includes the changes in https://github.com/jclouds/jclouds-karaf/pull/83. It should be merged once both PRs are merged (the build will fail until then).

I'm submitting it for an early review.

The `azurecompute-arm` provider depends on the OkHttp driver, but there are no OSGi bundles for the version of OkHttp we currently support and its transitive dependency, Okio. I've added the corresponding bundles here. There are bundles in servicemix for both libraries, but for newer verions. We should consider submitting a pull request there and replace our custom bundles. However, OkHttp comes with several module we don't use and a proper PR to servicemix should include those modules too. I'd like to focus on what we really need so we can include this as soon as possible for the 2.0 release, and once that is done, take time to create proper bundles for all OkHttp modules and move to servicemix.

@demobox WDYT?