### PR TITLE
Take into account the credentials file in GCE

### DIFF
--- a/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobStoreCommandWithOptions.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobStoreCommandWithOptions.java
@@ -90,7 +90,7 @@ public abstract class BlobStoreCommandWithOptions extends BlobStoreCommandBase {
       String identityValue = EnvHelper.getBlobStoreIdentity(identity);
       String credentialValue = EnvHelper.getBlobStoreCredential(credential);
       if (providerValue.equals("google-cloud-storage")) {
-         credentialValue = EnvHelper.getGoogleCredentialFromJsonFile(credentialValue);
+         credentialValue = EnvHelper.getGoogleCredentialFromJsonFileIfPath(credentialValue);
       }
       String endpointValue = EnvHelper.getBlobStoreEndpoint(endpoint);
       boolean contextNameProvided = !Strings.isNullOrEmpty(name);

--- a/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeCommandWithOptions.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeCommandWithOptions.java
@@ -87,7 +87,7 @@ public abstract class ComputeCommandWithOptions extends ComputeCommandBase {
       String apiValue = EnvHelper.getComputeApi(api);
       String identityValue = EnvHelper.getComputeIdentity(identity);
       String credentialValue = EnvHelper.getComputeCredential(credential);
-      if (providerValue != null && credentialValue != null && providerValue.equals("google-compute-engine")) {
+      if (credentialValue != null && providerValue != null && providerValue.startsWith("google")) {
          credentialValue = EnvHelper.getGoogleCredentialFromJsonFile(credentialValue);
       }
       String endpointValue = EnvHelper.getComputeEndpoint(endpoint);

--- a/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeCommandWithOptions.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeCommandWithOptions.java
@@ -88,7 +88,7 @@ public abstract class ComputeCommandWithOptions extends ComputeCommandBase {
       String identityValue = EnvHelper.getComputeIdentity(identity);
       String credentialValue = EnvHelper.getComputeCredential(credential);
       if (credentialValue != null && providerValue != null && providerValue.startsWith("google")) {
-         credentialValue = EnvHelper.getGoogleCredentialFromJsonFile(credentialValue);
+         credentialValue = EnvHelper.getGoogleCredentialFromJsonFileIfPath(credentialValue);
       }
       String endpointValue = EnvHelper.getComputeEndpoint(endpoint);
       boolean contextNameProvided = !Strings.isNullOrEmpty(name);

--- a/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeServiceCreateCommand.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeServiceCreateCommand.java
@@ -147,7 +147,7 @@ public class ComputeServiceCreateCommand extends ComputeCommandWithOptions {
                   String endpointValue = EnvHelper.getComputeEndpoint(endpoint);
                   String credentialValue = EnvHelper.getComputeCredential(credential);
                   if (credentialValue != null && providerValue != null && providerValue.startsWith("google")) {
-                     credentialValue = EnvHelper.getGoogleCredentialFromJsonFile(credentialValue);
+                     credentialValue = EnvHelper.getGoogleCredentialFromJsonFileIfPath(credentialValue);
                   }
 
                   if (name != null) {

--- a/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeServiceCreateCommand.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeServiceCreateCommand.java
@@ -136,7 +136,6 @@ public class ComputeServiceCreateCommand extends ComputeCommandWithOptions {
             try {
                Configuration configuration = findOrCreateFactoryConfiguration(configurationAdmin, "org.jclouds.compute", name, provider, api);
                if (configuration != null) {
-                  @SuppressWarnings("unchecked")
                   Dictionary<String, Object> dictionary = configuration.getProperties();
                   if (dictionary == null) {
                      dictionary = new Hashtable<String, Object>();
@@ -147,7 +146,7 @@ public class ComputeServiceCreateCommand extends ComputeCommandWithOptions {
                   String identityValue = EnvHelper.getComputeIdentity(identity);
                   String endpointValue = EnvHelper.getComputeEndpoint(endpoint);
                   String credentialValue = EnvHelper.getComputeCredential(credential);
-                  if (providerValue != null && credentialValue != null && providerValue.equals("google-compute-engine")) {
+                  if (credentialValue != null && providerValue != null && providerValue.startsWith("google")) {
                      credentialValue = EnvHelper.getGoogleCredentialFromJsonFile(credentialValue);
                   }
 

--- a/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeServiceCreateCommand.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeServiceCreateCommand.java
@@ -145,8 +145,11 @@ public class ComputeServiceCreateCommand extends ComputeCommandWithOptions {
                   String providerValue = EnvHelper.getComputeProvider(provider);
                   String apiValue = EnvHelper.getComputeApi(api);
                   String identityValue = EnvHelper.getComputeIdentity(identity);
-                  String credentialValue = EnvHelper.getComputeCredential(credential);
                   String endpointValue = EnvHelper.getComputeEndpoint(endpoint);
+                  String credentialValue = EnvHelper.getComputeCredential(credential);
+                  if (providerValue != null && credentialValue != null && providerValue.equals("google-compute-engine")) {
+                     credentialValue = EnvHelper.getGoogleCredentialFromJsonFile(credentialValue);
+                  }
 
                   if (name != null) {
                     dictionary.put(Constants.NAME, name);

--- a/utils/src/main/java/org/jclouds/karaf/utils/EnvHelper.java
+++ b/utils/src/main/java/org/jclouds/karaf/utils/EnvHelper.java
@@ -99,19 +99,23 @@ public class EnvHelper {
 
     /**
      * Extracts the credential value from the Google Cloud credentials json file.
-     * @param jsonFile
+     * @param credentialValue
      * @return
      */
-    public static String getGoogleCredentialFromJsonFile(String jsonFile) {
-        try {
-            String fileContents = Files.toString(new File(jsonFile), Charsets.UTF_8);
+   public static String getGoogleCredentialFromJsonFile(String credentialValue) {
+      File credentialsFile = new File(credentialValue);
+      if (credentialsFile.exists()) {
+         try {
+            String fileContents = Files.toString(credentialsFile, Charsets.UTF_8);
             Supplier<Credentials> credentialSupplier = new GoogleCredentialsFromJson(fileContents);
-            String credential = credentialSupplier.get().credential;
-            return credential;
+            return credentialSupplier.get().credential;
          } catch (IOException e) {
             return null;
          }
-    }
+      } else {
+         return credentialValue;
+      }
+   }
 
     /**
      * Returns the endpoint value and falls back to env if the specified value is null.

--- a/utils/src/main/java/org/jclouds/karaf/utils/EnvHelper.java
+++ b/utils/src/main/java/org/jclouds/karaf/utils/EnvHelper.java
@@ -102,7 +102,7 @@ public class EnvHelper {
      * @param credentialValue
      * @return
      */
-   public static String getGoogleCredentialFromJsonFile(String credentialValue) {
+   public static String getGoogleCredentialFromJsonFileIfPath(String credentialValue) {
       File credentialsFile = new File(credentialValue);
       if (credentialsFile.exists()) {
          try {


### PR DESCRIPTION
When configuring the credential for GCE, you can pass the key in PEM format as a String, or you can pass (for conevnience) a JSON file with the credentials. This was [enabled in all compute commands](https://github.com/jclouds/jclouds-karaf/blob/master/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeCommandWithOptions.java#L90-L92) but was not taken into account in reusable compute services.

This change allows reusable compute services to use the credentials file in addition to the PEM string.