### PR TITLE
Properly encapsulate google credential processing

### DIFF
--- a/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobStoreCommandWithOptions.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobStoreCommandWithOptions.java
@@ -88,10 +88,7 @@ public abstract class BlobStoreCommandWithOptions extends BlobStoreCommandBase {
       String providerValue = EnvHelper.getBlobStoreProvider(provider);
       String apiValue = EnvHelper.getBlobStoreApi(api);
       String identityValue = EnvHelper.getBlobStoreIdentity(identity);
-      String credentialValue = EnvHelper.getBlobStoreCredential(credential);
-      if (providerValue.equals("google-cloud-storage")) {
-         credentialValue = EnvHelper.getGoogleCredentialFromJsonFileIfPath(credentialValue);
-      }
+      String credentialValue = EnvHelper.getBlobStoreCredential(providerValue, credential);
       String endpointValue = EnvHelper.getBlobStoreEndpoint(endpoint);
       boolean contextNameProvided = !Strings.isNullOrEmpty(name);
       boolean canCreateService = (!Strings.isNullOrEmpty(providerValue) || !Strings.isNullOrEmpty(apiValue))

--- a/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobStoreServiceCreateCommand.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/blobstore/BlobStoreServiceCreateCommand.java
@@ -146,7 +146,7 @@ public class BlobStoreServiceCreateCommand extends BlobStoreCommandWithOptions {
                   String providerValue = EnvHelper.getBlobStoreProvider(provider);
                   String apiValue = EnvHelper.getBlobStoreApi(api);
                   String identityValue = EnvHelper.getBlobStoreIdentity(identity);
-                  String credentialValue = EnvHelper.getBlobStoreCredential(credential);
+                  String credentialValue = EnvHelper.getBlobStoreCredential(providerValue, credential);
                   String endpointValue = EnvHelper.getBlobStoreEndpoint(endpoint);
 
                  if (id != null) {

--- a/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeCommandWithOptions.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeCommandWithOptions.java
@@ -86,10 +86,7 @@ public abstract class ComputeCommandWithOptions extends ComputeCommandBase {
       String providerValue = EnvHelper.getComputeProvider(provider);
       String apiValue = EnvHelper.getComputeApi(api);
       String identityValue = EnvHelper.getComputeIdentity(identity);
-      String credentialValue = EnvHelper.getComputeCredential(credential);
-      if (credentialValue != null && providerValue != null && providerValue.startsWith("google")) {
-         credentialValue = EnvHelper.getGoogleCredentialFromJsonFileIfPath(credentialValue);
-      }
+      String credentialValue = EnvHelper.getComputeCredential(providerValue, credential);
       String endpointValue = EnvHelper.getComputeEndpoint(endpoint);
       boolean contextNameProvided = !Strings.isNullOrEmpty(name);
       boolean canCreateService = (!Strings.isNullOrEmpty(providerValue) || !Strings.isNullOrEmpty(apiValue))

--- a/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeServiceCreateCommand.java
+++ b/commands/src/main/java/org/jclouds/karaf/commands/compute/ComputeServiceCreateCommand.java
@@ -145,10 +145,7 @@ public class ComputeServiceCreateCommand extends ComputeCommandWithOptions {
                   String apiValue = EnvHelper.getComputeApi(api);
                   String identityValue = EnvHelper.getComputeIdentity(identity);
                   String endpointValue = EnvHelper.getComputeEndpoint(endpoint);
-                  String credentialValue = EnvHelper.getComputeCredential(credential);
-                  if (credentialValue != null && providerValue != null && providerValue.startsWith("google")) {
-                     credentialValue = EnvHelper.getGoogleCredentialFromJsonFileIfPath(credentialValue);
-                  }
+                  String credentialValue = EnvHelper.getComputeCredential(providerValue, credential);
 
                   if (name != null) {
                     dictionary.put(Constants.NAME, name);

--- a/utils/src/main/java/org/jclouds/karaf/utils/EnvHelper.java
+++ b/utils/src/main/java/org/jclouds/karaf/utils/EnvHelper.java
@@ -89,12 +89,13 @@ public class EnvHelper {
     /**
      * Returns the credential value and falls back to env if the specified value is null.
      *
+     * @param The provider id
      * @param credential
      * @return
      */
-    public static String getComputeCredential(String credential) {
-        return getValueOrPropertyOrEnvironmentVariable(
-            credential, Constants.PROPERTY_CREDENTIAL, JCLOUDS_COMPUTE_CREDENTIAL);
+    public static String getComputeCredential(String provider, String credential) {
+        return getCredentialValue(provider, getValueOrPropertyOrEnvironmentVariable(
+            credential, Constants.PROPERTY_CREDENTIAL, JCLOUDS_COMPUTE_CREDENTIAL));
     }
 
     /**
@@ -102,7 +103,7 @@ public class EnvHelper {
      * @param credentialValue
      * @return
      */
-   public static String getGoogleCredentialFromJsonFileIfPath(String credentialValue) {
+   private static String getGoogleCredentialFromJsonFileIfPath(String credentialValue) {
       File credentialsFile = new File(credentialValue);
       if (credentialsFile.exists()) {
          try {
@@ -163,12 +164,13 @@ public class EnvHelper {
     /**
      * Returns the credential value and falls back to env if the specified value is null.
      *
+     * @param The provider id
      * @param credential
      * @return
      */
-    public static String getBlobStoreCredential(String credential) {
-        return getValueOrPropertyOrEnvironmentVariable(
-            credential, Constants.PROPERTY_CREDENTIAL, JCLOUDS_BLOBSTORE_CREDENTIAL);
+    public static String getBlobStoreCredential(String provider, String credential) {
+        return getCredentialValue(provider, getValueOrPropertyOrEnvironmentVariable(
+            credential, Constants.PROPERTY_CREDENTIAL, JCLOUDS_BLOBSTORE_CREDENTIAL));
     }
 
     /**
@@ -238,4 +240,12 @@ public class EnvHelper {
         }
         return value;
     }
+    
+   private static String getCredentialValue(String provider, String credential) {
+      return credential != null && isGoogleCloud(provider) ? getGoogleCredentialFromJsonFileIfPath(credential) : credential;
+   }
+   
+   private static boolean isGoogleCloud(String provider) {
+      return provider != null && provider.startsWith("google");
+   }
 }


### PR DESCRIPTION
This is the continuation of https://github.com/jclouds/jclouds-karaf/pull/87, to properly encapsulate the Google Cloud credentials logic and reuse it in compute and blob store.

/cc @demobox @andrewgaul 