### PR TITLE
Fixes hardcoded karaf etc path in `jclouds-services` feature

### DIFF
--- a/feature/src/main/resources/feature.xml
+++ b/feature/src/main/resources/feature.xml
@@ -409,7 +409,7 @@ limitations under the License.
     </feature>
 
     <feature name="jclouds-services" description="OSGi Service Factories for jclouds" version="${project.version}" resolver="(obr)">
-        <configfile finalname="/etc/org.apache.jclouds.credentials.cfg">mvn:org.apache.jclouds.karaf/jclouds-karaf/${project.version}/cfg/credentials</configfile>
+        <configfile finalname="${karaf.etc}/org.apache.jclouds.credentials.cfg">mvn:org.apache.jclouds.karaf/jclouds-karaf/${project.version}/cfg/credentials</configfile>
         <feature version='${project.version}'>jclouds-compute</feature>
         <feature version='${project.version}'>jclouds-blobstore</feature>
         <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jsch/${jsch.bundle.version}</bundle>


### PR DESCRIPTION
It is good practice to use the provided variables as the karaf etc directory is not always located at `<karaf-install>/etc`