### PR TITLE
Attach config files referenced in the features as artifacts

### DIFF
--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -31,6 +31,35 @@ limitations under the License.
 
   <build>
     <plugins>
+      <!-- Attaches config files referenced in feature.xml (mvn protocol) as artifacts -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${build-helper-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>attach-feature-config</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>src/main/resources/credentials.cfg</file>
+                  <type>cfg</type>
+                  <classifier>credentials</classifier>
+                </artifact>
+                <artifact>
+                  <file>src/main/resources/shell.cfg</file>
+                  <type>cfg</type>
+                  <classifier>shell</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>


### PR DESCRIPTION
Adds back (a bit simplified) the maven config which creates artifacts out of the config files used in the feature.xml.

Tested by:
  * deleting my local repo for 2.1.0-SNAPSHOT
  * rebuilding the project
  * comparing file listing and the content of shell, credentials between 2.1.0-SNAPSHOT and 2.0.1 in my local repo