### PR TITLE
Remove labs features from the main feature set and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,29 +2,29 @@
 
 This project currently hosts a Karaf feature repository for easy installation of jclouds inside Apache Karaf. It also provides Managed Service Factories for creating Compute and BlobStore services. Last but not least it provides a rich command set for using jclouds from the Karaf shell.
 
-There is also support for using chef via [jclouds-chef](https://github.com/jclouds/jclouds-chef/) integration.
+There is also support for using Chef via the [jclouds Chef integration](https://jclouds.apache.org/guides/chef/).
 
 Usage Instructions
 ==================
 The instructions will make use of Amazon EC2 and S3, but can be applied to any provider or api supported by jclouds.
 
-On Karaf 2.2.5 or later:
+On Karaf 4.0.x or later:
 
 Install jclouds AWS Modules
 ---------------------------
 Install the feature and a provider for blobstore and compute service:
 
-    karaf@root> features:addurl mvn:org.jclouds.karaf/jclouds-karaf/1.5.0/xml/features
-    karaf@root> features:install jclouds-aws-s3
-    karaf@root> features:install jclouds-aws-ec2
+    karaf@root()> feature:repo-add mvn:org.apache.jclouds.karaf/jclouds-karaf/2.1.0-SNAPSHOT/xml/features
+    karaf@root()> feature:install jclouds-aws-s3
+    karaf@root()> feature:install jclouds-aws-ec2
 
 Install Karaf Commands:
 
-    karaf@root> features:install jclouds-commands
+    karaf@root()> feature:install jclouds-commands
 
 To see the list of available jclouds modules for Karaf
 
-    karaf@root> features:list | grep jclouds
+    karaf@root()> feature:list | grep jclouds
 
 Compute Service
 ---------------
@@ -39,16 +39,16 @@ There are currently two ways of creating a compute service:
 The compute service command allows you to create a reusable compute service for a jclouds provider or api.
 To create a compute service for the EC2 provider:
 
-    karaf@root> jclouds:compute-service-create --provider aws-ec2 --identity XXXXXX --credential XXXXXXX
+    karaf@root()> jclouds:compute-service-create --provider aws-ec2 --identity XXXXXX --credential XXXXXXX
 
 and for creating a compute service using an api, for example openstack:
 
-    karaf@root> jclouds:compute-service-create --api openstack-nova --endpoint XXXXXXXX --identity XXXXXX --credential XXXXXXX
+    karaf@root()> jclouds:compute-service-create --api openstack-nova --endpoint XXXXXXXX --identity XXXXXX --credential XXXXXXX
 
 Note that when using apis you usually need to also specify the endpoint too. The command also supports adding extra options
 as key/value pairs. For example:
 
-    karaf@root> jclouds:compute-service-create --api openstack-nova --endpoint XXXXXXXX --identity XXXXXX --credential XXXXXXX --add-option jclouds.keystone.credential-type=passwordCredentials
+    karaf@root()> jclouds:compute-service-create --api openstack-nova --endpoint XXXXXXXX --identity XXXXXX --credential XXXXXXX --add-option jclouds.keystone.credential-type=passwordCredentials
 
 To see the list of installed providers and apis or remove the service for one of the providers, you can use the jclouds:compute-service-list and jclouds-compute-service-remove commands.
 
@@ -56,41 +56,40 @@ To see the list of installed providers and apis or remove the service for one of
 
 To create a compute service using the Karaf's integration with the configuration admin all that needs to be done is to create a configuration with factory pid: org.jclouds.compute.
 
-    karaf@root> config:edit  org.jclouds.compute-ec2
-    karaf@root> config:propset provider aws-ec2
-    karaf@root> config:propset identity XXXXXXXXX
-    karaf@root> config:propset credential XXXXXXXXX
-    karaf@root> config:propset jclouds.ec2.ami-owners  XXXXXXXXX
-    karaf@root> config:update
+    karaf@root()> config:edit  org.jclouds.compute-ec2
+    karaf@root()> config:property-set provider aws-ec2
+    karaf@root()> config:property-set identity XXXXXXXXX
+    karaf@root()> config:property-set credential XXXXXXXXX
+    karaf@root()> config:property-set jclouds.ec2.ami-owners  XXXXXXXXX
+    karaf@root()> config:update
 
 Use the compute service commands
 
-    karaf@root> jclouds:node-create --imageId YOUR_IMAGE_ID --locationId YOUR_LOCATION_ID GROUPNAME
-    karaf@root> jclouds:node-list.
+    karaf@root()> jclouds:node-create --imageId YOUR_IMAGE_ID --locationId YOUR_LOCATION_ID GROUPNAME
+    karaf@root()> jclouds:node-list.
 
 If you don't want/need to specify specific image, you specify the os family and the os version
 
-    karaf@root> jclouds:node-create --os-family OS_FAMILY --os-version OS_VERSION --locationId YOUR_LOCATION_ID GROUPNAME
+    karaf@root()> jclouds:node-create --os-family OS_FAMILY --os-version OS_VERSION --locationId YOUR_LOCATION_ID GROUPNAME
 
-<b>Note:</b> You can supply additional options to select hardware etc.
-
+**Note:** You can supply additional options to select hardware etc.
 
 Run a script to a single node or a group of nodes:
 
-    karaf@root> jclouds:group-runscript --script-url URL_OF_THE_SCRIPT GROUPNAME.
-    karaf@root> jclouds:node-runscript --script-url URL_OF_THE_SCRIPT NODEID.
+    karaf@root()> jclouds:group-runscript --script-url URL_OF_THE_SCRIPT GROUPNAME.
+    karaf@root()> jclouds:node-runscript --script-url URL_OF_THE_SCRIPT NODEID.
 
 For simple commands you can just inline the command, for example to get the uptime of the node:
 
-    karaf@root> jclouds:group-runscript --direct uptime GROUPNAME.
-    karaf@root> jclouds:node-runscript --direct uptime NODEID.
+    karaf@root()> jclouds:group-runscript --direct uptime GROUPNAME.
+    karaf@root()> jclouds:node-runscript --direct uptime NODEID.
 
 Or you can use whatever command you want.
 
 Shutdown all your nodes or the nodes of a specific group:
 
-    karaf@root> jclouds:group-destroy GROUPNAME
-    karaf@root> jclouds:node-destroy-all GROUPNAME
+    karaf@root()> jclouds:group-destroy GROUPNAME
+    karaf@root()> jclouds:node-destroy-all GROUPNAME
 
 
 BlobStore
@@ -105,31 +104,31 @@ There are currently two ways of creating a service for blobstore service:
 The compute service command allows you to create and reuse blobstore service for a jclouds provider or api.
 To create a compute service for the S3 provider:
 
-    karaf@root> jclouds:blobstore-service-create --provider aws-s3 --identity XXXXXX --credential XXXXXXX
+    karaf@root()> jclouds:blobstore-service-create --provider aws-s3 --identity XXXXXX --credential XXXXXXX
 
 To see the list of installed providers and apis or remove the service for one of the providers, you can use the jclouds:blobstore-service-list and jclouds-blobstore-service-remove commands.
 
 **Using the Karaf config commands**
 Create a sample blobstore service, by using the console:
 
-    karaf@root> config:edit  org.jclouds.blobstore-s3
-    karaf@root> config:propset provider aws-s3
-    karaf@root> config:propset identity XXXXXXXXX
-    karaf@root> config:propset credential XXXXXXXXX
-    karaf@root> config:update
+    karaf@root()> config:edit  org.jclouds.blobstore-s3
+    karaf@root()> config:property-set provider aws-s3
+    karaf@root()> config:property-set identity XXXXXXXXX
+    karaf@root()> config:property-set credential XXXXXXXXX
+    karaf@root()> config:update
 
 You can use the shell commands to list, create, delete, read or write to a blob:
 
-    karaf@root> jclouds:blobstore-write BUCKET_NAME BLOB_NAME payload
-    karaf@root> jclouds:blobstore-read BUCKET_NAME BLOB_NAME
+    karaf@root()> jclouds:blobstore-write BUCKET_NAME BLOB_NAME payload
+    karaf@root()> jclouds:blobstore-read BUCKET_NAME BLOB_NAME
 
 This works well for String payloads, but for binary payloads the user can use the url to be used as input or output for the commands:
 
-    karaf@root> jclouds:blobstore-write BUCKET_NAME BLOB_NAME URL_POINTING_TO_THE_PAYLOAD.
-    karaf@root> jclouds:blobstore-read BUCKET_NAME BLOB_NAME LOCAL_FILE_TO_STORE_THE_BLOB.
+    karaf@root()> jclouds:blobstore-write BUCKET_NAME BLOB_NAME URL_POINTING_TO_THE_PAYLOAD.
+    karaf@root()> jclouds:blobstore-read BUCKET_NAME BLOB_NAME LOCAL_FILE_TO_STORE_THE_BLOB.
 
 If the payload represents a URI the content of the URL will be written instead.
-You can bypass this by specifying the <i>--store-url</i> and store the url as a string.
+You can bypass this by specifying the *--store-url* and store the url as a string.
 
 BlobStore URL Handler
 ---------------------
@@ -138,67 +137,61 @@ Jclouds Karaf also provides a url handler which will allow you to use blobstore 
 
 <b>blob:/PROVIDER/CONTAINER/BLOB</b>
 
-<b>A Funny Example:</b>
-You can copy a bundle to a blob and install it directly from there:
-
-    karaf@root> features:install jclouds-url-handler
-    karaf@root>osgi:install -s blob:/PROVIDER/CONTAINER/PATH_TO_BUNDLE
-
 Chef
 ----
 You can install the chef api, with the following command:
 
-    karaf@root> features:install jclouds-chef-api
+    karaf@root()> feature:install jclouds-chef-api
 
 Managed Service Factories and commands are also provided for Chef. The managed service factory allows you to create a reusable service just by passing the configuration. To install the managed service factories and the chef commands, you need to install the jclouds-chef feature:
 
-    karaf@root>features:install jclouds-chef
+    karaf@root()>feature:install jclouds-chef
 
 Then you can create a chef service, using the chef:service-create command:
 
-    karaf@root>chef:service-create  --api chef --client-name CLIENT --validator-name VALIDATOR --client-key-file CLIENT.pem --validator-key-file VALIDATOR.pem --endpoint ENDPOINT
+    karaf@root()> chef:service-create  --api chef --client-name CLIENT --validator-name VALIDATOR --client-key-file CLIENT.pem --validator-key-file VALIDATOR.pem --endpoint ENDPOINT
 
 **OPSCODE Chef Example:**
 The above command for opscode chef, with client iocanel and validator iocanel-validator, the command looks like:
 
-    karaf@root>chef:service-create  --api chef --client-name iocanel --validator-name iocanel-validator --client-key-file /Users/iocanel/.chef/iocanel.pem --validator-key-file /Users/iocanel/.chef/iocanel-validator.pem --endpoint https://api.opscode.com/organizations/iocanel
+    karaf@root()> chef:service-create  --api chef --client-name iocanel --validator-name iocanel-validator --client-key-file /Users/iocanel/.chef/iocanel.pem --validator-key-file /Users/iocanel/.chef/iocanel-validator.pem --endpoint https://api.opscode.com/organizations/iocanel
 
 Once the service has been create, you can list your cookbooks using:
 
-    karaf@root>chef:cookbook-list
+    karaf@root()> chef:cookbook-list
 
 **Using the Chef Service with any Provider / Api:**
 Once you have created the chef service and have made sure a couple of cookbooks are uploaded. You can use chef with any other compute service in your system.
 In the example above it will be used with EC2:
 
-    karaf@root>node-create --imageId eu-west-1/ami-c1aaabb5 --hardwareId m1.medium --adminAccess  karaf
+    karaf@root()> node-create --imageId eu-west-1/ami-c1aaabb5 --hardwareId m1.medium --adminAccess  karaf
 
     [id]                 [location] [hardware] [group]   [status]
     eu-west-1/i-bbb5eff0 eu-west-1c m1.medium  karafchef RUNNING
 
-    karaf@root>chef:node-bootstrap  eu-west-1/i-bbb5eff0 java::openjdk
+    karaf@root()> chef:node-bootstrap  eu-west-1/i-bbb5eff0 java::openjdk
 
 The above can be also performed in a single step using the --recipe option:
 
-    karaf@root>node-create --imageId eu-west-1/ami-c1aaabb5 --hardwareId m1.medium --adminAccess --recipe chef/java::openjdk karaf
+    karaf@root()> node-create --imageId eu-west-1/ami-c1aaabb5 --hardwareId m1.medium --adminAccess --recipe chef/java::openjdk karaf
 
 
 Using multiple services per provider/api
 ----------------------------------------
 
 As of jclouds-karaf 1.5.0 you are able to register multiple compute and blobstore services per provider or api. The commands will allow you to specify which service to use (just specifying provider/api isn't enough since we have multiple services).
-To "name" the service, you can use the --id option in the service create commands. If no id is specified the provider/api name will be used instead.
+To "name" the service, you can use the --name option in the service create commands. If no id is specified the provider/api name will be used instead.
 
 For compute services:
 
-    jclouds:compute-service-create --id aws1 --provider aws-ec2 ...
-    jclouds:node-list --id aws1
+    jclouds:compute-service-create --name aws1 --provider aws-ec2 ...
+    jclouds:node-list --name aws1
 
 
 This can be very useful when you want to configure either different accounts per provider/api or use different configuration options. A small example:
 
-    jclouds:compute-service-create --id aws-eu-west-1 --provider aws-ec2 --add-option jclouds.regions=eu-west-1
-    jclouds:compute-service-create --id aws-us-east-1 --provider aws-ec2 --add-option jclouds.regions=us-east-1
+    jclouds:compute-service-create --name aws-eu-west-1 --provider aws-ec2 --add-option jclouds.regions=eu-west-1
+    jclouds:compute-service-create --name aws-us-east-1 --provider aws-ec2 --add-option jclouds.regions=us-east-1
 
 The available ids are now shown in the compute-service-list commands:
 
@@ -223,7 +216,7 @@ To destroy one of the two available services:
 
 Blobstore services work in a very similar manner:
 
-    jclouds:blobstore-service-create --id s3-1 --provider aws-s3 ...
+    jclouds:blobstore-service-create --name s3-1 --provider aws-s3 ...
 
 
 Using environmental variables

--- a/feature-labs/src/main/feature/feature.xml
+++ b/feature-labs/src/main/feature/feature.xml
@@ -26,6 +26,7 @@ limitations under the License.
         <feature version='${project.version}'>jclouds-api-cloudsigma2</feature>
         <feature version='${project.version}'>jclouds-cloudsigma2-hnl</feature>
         <feature version='${project.version}'>jclouds-cloudsigma2-lvs</feature>
+        <feature version='${project.version}'>jclouds-cloudsigma2-mia</feature>
         <feature version='${project.version}'>jclouds-cloudsigma2-sjc</feature>
         <feature version='${project.version}'>jclouds-cloudsigma2-wdc</feature>
         <feature version='${project.version}'>jclouds-cloudsigma2-zrh</feature>
@@ -59,6 +60,12 @@ limitations under the License.
         <feature version='${project.version}'>jclouds-compute</feature>
         <bundle dependency='true'>mvn:org.apache.jclouds.labs/cloudsigma2/${jclouds.version}</bundle>
         <bundle>mvn:org.apache.jclouds.labs/cloudsigma2-lvs/${jclouds.version}</bundle>
+    </feature>
+
+    <feature name='jclouds-cloudsigma2-mia' description='CloudSigma v2 Miami' version='${project.version}'>
+        <feature version='${project.version}'>jclouds-compute</feature>
+        <bundle dependency='true'>mvn:org.apache.jclouds.labs/cloudsigma2/${jclouds.version}</bundle>
+        <bundle>mvn:org.apache.jclouds.labs/cloudsigma2-mia/${jclouds.version}</bundle>
     </feature>
 
     <feature name='jclouds-cloudsigma2-sjc' description='CloudSigma v2 San Jose' version='${project.version}'>

--- a/feature/src/main/feature/feature.xml
+++ b/feature/src/main/feature/feature.xml
@@ -426,6 +426,18 @@ limitations under the License.
         <bundle>mvn:org.apache.jclouds.provider/softlayer/${jclouds.version}</bundle>
     </feature>
 
+    <feature name='jclouds-b2' description='Backblaze B2' version='${project.version}'>
+        <feature version='${project.version}'>jclouds-blobstore</feature>
+        <bundle>mvn:org.apache.jclouds.provider/b2/${jclouds.version}</bundle>
+    </feature>
+
+    <feature name='jclouds-google-cloud-storage' description='Google Cloud Storage' version='${project.version}'>
+        <feature version='${project.version}'>jclouds-blobstore</feature>
+        <feature version='${project.version}'>jclouds-api-oauth</feature>
+        <bundle dependency='true'>mvn:org.apache.jclouds.common/googlecloud/${jclouds.version}</bundle>
+        <bundle>mvn:org.apache.jclouds.provider/google-cloud-storage/${jclouds.version}</bundle>
+    </feature>
+
     <!-- DRIVERS -->
     <feature name="jclouds-driver-apachehc" description="Apache HTTP Components Client driver for jclouds" version="${project.version}">
         <feature version='${project.version}'>jclouds</feature>
@@ -500,59 +512,6 @@ limitations under the License.
         <bundle dependency="true">mvn:net.i2p.crypto/eddsa/0.1.0</bundle>
         <bundle dependency="true">mvn:com.hierynomus/sshj/0.20.0</bundle>
         <bundle>mvn:org.apache.jclouds.driver/jclouds-sshj/${jclouds.version}</bundle>
-    </feature>
-
-    <!-- JCLOUDS-LABS -->
-    <feature name='jclouds-azurecompute-arm' description='Components to access Azure Compute ARM' version='${project.version}'>
-        <feature version='${project.version}'>jclouds-compute</feature>
-        <feature version='${project.version}'>jclouds-azureblob</feature>
-        <feature version='${project.version}'>jclouds-api-oauth</feature>
-        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okio/${okio.bundle.version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okhttp/${okhttp.bundle.version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.jclouds.driver/jclouds-okhttp/${jclouds.version}</bundle>
-        <bundle>mvn:org.apache.jclouds.labs/azurecompute-arm/${jclouds.version}</bundle>
-    </feature>
-
-    <feature name='jclouds-b2' description='Backblaze B2' version='${project.version}'>
-        <feature version='${project.version}'>jclouds-blobstore</feature>
-        <bundle>mvn:org.apache.jclouds.provider/b2/${jclouds.version}</bundle>
-    </feature>
-
-    <feature name='jclouds-cloudsigma2-hnl' description='CloudSigma v2 Honolulu' version='${project.version}'>
-        <feature version='${project.version}'>jclouds-compute</feature>
-        <bundle dependency='true'>mvn:org.apache.jclouds.labs/cloudsigma2/${jclouds.version}</bundle>
-        <bundle>mvn:org.apache.jclouds.labs/cloudsigma2-hnl/${jclouds.version}</bundle>
-    </feature>
-
-    <feature name='jclouds-cloudsigma2-lvs' description='CloudSigma v2 Las Vegas' version='${project.version}'>
-        <feature version='${project.version}'>jclouds-compute</feature>
-        <bundle dependency='true'>mvn:org.apache.jclouds.labs/cloudsigma2/${jclouds.version}</bundle>
-        <bundle>mvn:org.apache.jclouds.labs/cloudsigma2-lvs/${jclouds.version}</bundle>
-    </feature>
-
-    <feature name='jclouds-cloudsigma2-sjc' description='CloudSigma v2 San Jose' version='${project.version}'>
-        <feature version='${project.version}'>jclouds-compute</feature>
-        <bundle dependency='true'>mvn:org.apache.jclouds.labs/cloudsigma2/${jclouds.version}</bundle>
-        <bundle>mvn:org.apache.jclouds.labs/cloudsigma2-sjc/${jclouds.version}</bundle>
-    </feature>
-
-    <feature name='jclouds-cloudsigma2-wdc' description='CloudSigma v2 Washington DC' version='${project.version}'>
-        <feature version='${project.version}'>jclouds-compute</feature>
-        <bundle dependency='true'>mvn:org.apache.jclouds.labs/cloudsigma2/${jclouds.version}</bundle>
-        <bundle>mvn:org.apache.jclouds.labs/cloudsigma2-wdc/${jclouds.version}</bundle>
-    </feature>
-
-    <feature name='jclouds-cloudsigma2-zrh' description='CloudSigma v2 Zurich' version='${project.version}'>
-        <feature version='${project.version}'>jclouds-compute</feature>
-        <bundle dependency='true'>mvn:org.apache.jclouds.labs/cloudsigma2/${jclouds.version}</bundle>
-        <bundle>mvn:org.apache.jclouds.labs/cloudsigma2-zrh/${jclouds.version}</bundle>
-    </feature>
-
-    <feature name='jclouds-google-cloud-storage' description='Google Cloud Storage' version='${project.version}'>
-        <feature version='${project.version}'>jclouds-blobstore</feature>
-        <feature version='${project.version}'>jclouds-api-oauth</feature>
-        <bundle dependency='true'>mvn:org.apache.jclouds.common/googlecloud/${jclouds.version}</bundle>
-        <bundle>mvn:org.apache.jclouds.provider/google-cloud-storage/${jclouds.version}</bundle>
     </feature>
 
     <!-- SERVICES -->

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@ limitations under the License.
     <junit.version>4.8.2</junit.version>
     <jzlib.bundle.version>1.0.7_1</jzlib.bundle.version>
     <jzlib.version>1.0.7</jzlib.version>
-    <karaf.version>4.0.8</karaf.version>
+    <karaf.version>4.0.9</karaf.version>
     <net.oauth.bundle.version>20100527_1</net.oauth.bundle.version>
     <netty.bundle.version>3.5.9.Final</netty.bundle.version>
     <osgi.version>6.0.0</osgi.version>


### PR DESCRIPTION
This PR upgrades to the latest available 4.0.9 and removes some labs features that were duplicated in the main feature set. It also adds the missing CloudSigma2 Miami provider in labs and updates the README to align the commands with the 4.0.x syntax.